### PR TITLE
Remove misc characters in code

### DIFF
--- a/src/storageExplorerLauncher/windowsStorageExplorerLauncher.ts
+++ b/src/storageExplorerLauncher/windowsStorageExplorerLauncher.ts
@@ -71,7 +71,7 @@ export class WindowsStorageExplorerLauncher implements IStorageExplorerLauncher 
     private static getWindowsRegistryValue(key: string): Promise<string> {
         return new Promise((resolve, reject) => {
             regedit.list([key])
-                .on('data',  (entry) =>  {
+                .on('data', (entry) => {
                     var value = <string>entry.data.values[""].value.split("\"")[1];
                     resolve(value);
                 })


### PR DESCRIPTION
These show up as Chinese in vscode, causing parse errors in the editor.