### PR TITLE
Open in portal for storage accounts

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,10 @@
 				}
 			},
 			{
+				"command": "azureStorage.openInPortal",
+				"title": "Open in Portal"
+			},
+			{
 				"command": "azureStorage.selectSubscriptions",
 				"title": "Select Subscriptions...",
 				"icon": {
@@ -75,7 +79,7 @@
 			},
 			{
 				"command": "azureStorage.openBlobContainer",
-				"title": "Open Blob Container in Storage Explorer",
+				"title": "Open in Storage Explorer",
 				"icon": {
 					"light": "resources/light/AzureStorageAccount_16x.png",
 					"dark": "resources/dark/AzureStorageAccount_16x.png"
@@ -83,7 +87,7 @@
 			},
 			{
 				"command": "azureStorage.openTable",
-				"title": "Open Table in Storage Explorer",
+				"title": "Open in Storage Explorer",
 				"icon": {
 					"light": "resources/light/AzureStorageAccount_16x.png",
 					"dark": "resources/dark/AzureStorageAccount_16x.png"
@@ -91,7 +95,7 @@
 			},
 			{
 				"command": "azureStorage.openFileShare",
-				"title": "Open File Share in Storage Explorer",
+				"title": "Open in Storage Explorer",
 				"icon": {
 					"light": "resources/light/AzureStorageAccount_16x.png",
 					"dark": "resources/dark/AzureStorageAccount_16x.png"
@@ -99,7 +103,7 @@
 			},
 			{
 				"command": "azureStorage.openQueue",
-				"title": "Open Queue in Storage Explorer",
+				"title": "Open in Storage Explorer",
 				"icon": {
 					"light": "resources/light/AzureStorageAccount_16x.png",
 					"dark": "resources/dark/AzureStorageAccount_16x.png"
@@ -107,7 +111,7 @@
 			},
 			{
 				"command": "azureStorage.openStorageAccount",
-				"title": "Open Storage Account in Storage Explorer",
+				"title": "Open in Storage Explorer",
 				"icon": {
 					"light": "resources/light/AzureStorageAccount_16x.png",
 					"dark": "resources/dark/AzureStorageAccount_16x.png"
@@ -215,6 +219,11 @@
 					"command": "azureStorage.openStorageAccount",
 					"when": "view == azureStorage && viewItem == azureStorageAccount",
 					"group": "navigation@1"
+				},
+				{
+					"command": "azureStorage.openInPortal",
+					"when": "view == azureStorage && viewItem == azureStorageAccount",
+					"group": "navigation@2"
 				},
 				{
 					"command": "azureStorage.copyConnectionString",
@@ -519,6 +528,10 @@
 				},
 				{
 					"command": "azureStorage.deleteQueue",
+					"when": "never"
+				},
+				{
+					"command": "azureStorage.openInPortal",
 					"when": "never"
 				}
 			]

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -58,4 +58,5 @@ export function activate(context: vscode.ExtensionContext): void {
     actionHandler.registerCommand('azureStorage.refresh', (node?: IAzureNode) => azureTreeDataProvider.refresh(node));
     actionHandler.registerCommand('azureStorage.copyUrl', (node?: IAzureNode<IAzureTreeItem & ICopyUrl>) => node.treeItem.copyUrl(node));
     actionHandler.registerCommand('azureStorage.selectSubscriptions', () => commands.executeCommand("azure-account.selectSubscriptions"));
+    actionHandler.registerCommand("azureStorage.openInPortal", (node: IAzureNode<IAzureTreeItem>) => node.openInPortal());
 }


### PR DESCRIPTION
Fixes #105 

@EricJizbaMSFT It's possible to get a link to a blob container via a URL like this:

https://ms.portal.azure.com/#blade/Microsoft_Azure_Storage/ContainerMenuBlade/overview/storageAccountId/%2Fsubscriptions%2<SUBID>%2FresourceGroups%2F<RESOURCE GROUP>%2Fproviders%2FMicrosoft.Storage%2FstorageAccounts%<STGACCT>/path/<BLOBCONTAINER>

I have no idea if this is safe to take a dependency on, do you know?  Thx.
