### PR TITLE
Browse static website...

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,11 @@
 				"category": "Azure Storage"
 			},
 			{
+				"command": "azureStorage.browseStaticWebsite",
+				"title": "Browse Static Website...",
+				"category": "Azure Storage"
+			},
+			{
 				"command": "azureStorage.selectSubscriptions",
 				"title": "Select Subscriptions...",
 				"icon": {
@@ -264,14 +269,19 @@
 					"group": "5_cutcopypaste@2"
 				},
 				{
-					"command": "azureStorage.deployStaticWebsite",
+					"command": "azureStorage.browseStaticWebsite",
 					"when": "view == azureStorage && viewItem == azureStorageAccount",
 					"group": "6_staticwebsites@1"
 				},
 				{
-					"command": "azureStorage.configureStaticWebsite",
+					"command": "azureStorage.deployStaticWebsite",
 					"when": "view == azureStorage && viewItem == azureStorageAccount",
 					"group": "6_staticwebsites@2"
+				},
+				{
+					"command": "azureStorage.configureStaticWebsite",
+					"when": "view == azureStorage && viewItem == azureStorageAccount",
+					"group": "6_staticwebsites@3"
 				},
 				{
 					"command": "azureStorage.refresh",
@@ -319,6 +329,11 @@
 					"command": "azureStorage.configureStaticWebsite",
 					"when": "view == azureStorage && viewItem == azureBlobContainer",
 					"group": "6_staticwebsites@2"
+				},
+				{
+					"command": "azureStorage.browseStaticWebsite",
+					"when": "view == azureStorage && viewItem == azureBlobContainer",
+					"group": "6_staticwebsites@3"
 				},
 				{
 					"command": "azureStorage.deleteBlobContainer",
@@ -587,6 +602,9 @@
 				},
 				{
 					"command": "azureStorage.deployStaticWebsite"
+				},
+				{
+					"command": "azureStorage.browseStaticWebsite"
 				}
 			]
 		},
@@ -632,6 +650,7 @@
 		"@types/glob": "^5.0.35",
 		"@types/mocha": "^2.2.42",
 		"@types/node": "^7.0.43",
+		"@types/opn": "5.1.0",
 		"@types/winreg": "1.2.30",
 		"gulp": "^3.9.1",
 		"tslint": "^5.7.0",
@@ -644,14 +663,15 @@
 		"ms-vscode.azure-account"
 	],
 	"dependencies": {
-		"azure-arm-resource": "^2.0.0-preview",
-		"azure-arm-storage": "^3.1.0",
-		"azure-storage": "^2.9.0-preview",
+		"azure-arm-resource": "^3.1.1-preview",
+		"azure-arm-storage": "^5.1.1-preview",
+		"azure-storage": "^2.10.0",
 		"copy-paste": "^1.3.0",
 		"fs-extra": "^4.0.2",
 		"glob": "^7.1.2",
 		"ms-rest": "^2.2.2",
 		"ms-rest-azure": "^2.3.1",
+		"opn": "^5.3.0",
 		"vscode-extension-telemetry": "^0.0.15",
 		"vscode-azureextensionui": "~0.16.0",
 		"winreg": "^1.2.3"

--- a/src/azureStorageExplorer/blobContainers/blobContainerNode.ts
+++ b/src/azureStorageExplorer/blobContainers/blobContainerNode.ts
@@ -332,7 +332,7 @@ export class BlobContainerNode implements IAzureParentTreeItem, ICopyUrl {
                 throw new Error(`Could not obtain the primary web endpoint for ${this.storageAccount.name}`);
             }
 
-            ext.outputChannel.appendLine(`Deployment to static website complete. CTRL+Click to browse: ${webEndpoint}`);
+            ext.outputChannel.appendLine(`Deployment to static website complete. Primary web endpoint is ${webEndpoint}`);
 
             return webEndpoint;
         } catch (error) {
@@ -344,7 +344,7 @@ export class BlobContainerNode implements IAzureParentTreeItem, ICopyUrl {
     }
 
     public getPrimaryWebEndpoint(): string | undefined {
-        // Right now we only support only web endpoint per storage account
+        // Right now only one web endpoint is supported per storage account
         return this.storageAccount.primaryEndpoints.web;
     }
 
@@ -357,7 +357,7 @@ export class BlobContainerNode implements IAzureParentTreeItem, ICopyUrl {
         if (storageAccountNode && storageAccountNode.treeItem instanceof StorageAccountNode) {
             return <IAzureParentNode<StorageAccountNode>>storageAccountNode;
         } else {
-            throw new Error("Couldn't find storage account node for container");
+            throw new Error("Internal error: Couldn't find storage account node for container");
         }
     }
     private async uploadFiles(

--- a/src/azureStorageExplorer/blobContainers/blobContainerNode.ts
+++ b/src/azureStorageExplorer/blobContainers/blobContainerNode.ts
@@ -7,8 +7,6 @@ import * as azureStorage from "azure-storage";
 import * as copypaste from 'copy-paste';
 import * as fse from 'fs-extra';
 import * as glob from 'glob';
-// tslint:disable-next-line:no-require-imports
-import opn = require('opn');
 import * as path from 'path';
 import { ProgressLocation, Uri } from 'vscode';
 import * as vscode from 'vscode';

--- a/src/azureStorageExplorer/blobContainers/blobContainerNode.ts
+++ b/src/azureStorageExplorer/blobContainers/blobContainerNode.ts
@@ -7,14 +7,17 @@ import * as azureStorage from "azure-storage";
 import * as copypaste from 'copy-paste';
 import * as fse from 'fs-extra';
 import * as glob from 'glob';
+// tslint:disable-next-line:no-require-imports
+import opn = require('opn');
 import * as path from 'path';
-import * as vscode from 'vscode';
 import { ProgressLocation, Uri } from 'vscode';
+import * as vscode from 'vscode';
 import { DialogResponses, IActionContext, IAzureNode, IAzureParentNode, IAzureParentTreeItem, IAzureTreeItem, parseError, TelemetryProperties, UserCancelledError } from 'vscode-azureextensionui';
 import { StorageAccount, StorageAccountKey } from '../../../node_modules/azure-arm-storage/lib/models';
 import { awaitWithProgress } from '../../components/progress';
 import { ext } from "../../extensionVariables";
 import { ICopyUrl } from '../../ICopyUrl';
+import { StorageAccountNode } from "../storageAccounts/storageAccountNode";
 import { BlobFileHandler } from './blobFileHandler';
 import { BlobNode } from './blobNode';
 
@@ -206,8 +209,7 @@ export class BlobContainerNode implements IAzureParentTreeItem, ICopyUrl {
 
     public async deployStaticWebsite(node: IAzureParentNode<BlobContainerNode>, _actionContext: IActionContext, sourceFolderPath: string): Promise<void> {
         let destBlobFolder = "";
-
-        await vscode.window.withProgress(
+        let webEndpoint = await vscode.window.withProgress(
             {
                 cancellable: true,
                 location: ProgressLocation.Notification,
@@ -217,13 +219,13 @@ export class BlobContainerNode implements IAzureParentTreeItem, ICopyUrl {
             async (progress, cancellationToken) => await this.deployStaticWebsiteCore(_actionContext, sourceFolderPath, destBlobFolder, progress, cancellationToken),
         );
 
-        let goToPortal: vscode.MessageItem = { title: "Retrieve primary endpoint from portal" };
+        let browseWebsite: vscode.MessageItem = { title: "Browse to website" };
         let result = await vscode.window.showInformationMessage(
-            "Deployment complete. View the website using the primary web endpoint URL, which is available in the configure tab on the Azure portal.",
-            goToPortal
+            `Deployment complete. The primary web endpoint is ${webEndpoint}`,
+            browseWebsite
         );
-        if (result === goToPortal) {
-            vscode.commands.executeCommand("azureStorage.configureStaticWebsite", node);
+        if (result === browseWebsite) {
+            await vscode.commands.executeCommand('azureStorage.browseStaticWebsite', node);
         }
     }
 
@@ -231,13 +233,18 @@ export class BlobContainerNode implements IAzureParentTreeItem, ICopyUrl {
         return `${this.storageAccount.name}/${this.container.name}`;
     }
 
+    /**
+     * deployStaticWebsiteCore
+     *
+     * @returns The primary web endpoint
+     */
     private async deployStaticWebsiteCore(
         _actionContext: IActionContext,
         sourceFolderPath: string,
         destBlobFolder: string,
         progress: vscode.Progress<{ message?: string, increment?: number }>,
         cancellationToken: vscode.CancellationToken
-    ): Promise<void> {
+    ): Promise<string> {
         let properties = <TelemetryProperties & {
             blobsToDelete: number;
             filesToUpload: number;
@@ -256,7 +263,7 @@ export class BlobContainerNode implements IAzureParentTreeItem, ICopyUrl {
             properties.blobsToDelete = blobsToDelete.length;
 
             if (blobsToDelete.length) {
-                let message = `Are you sure you want to deploy to ${this.friendlyContainerName}?  This will delete all ${blobsToDelete.length} files currently in the ${this.friendlyContainerName} blob container.`;
+                let message = `The storage container "${this.friendlyContainerName}" contains ${blobsToDelete.length} files. Deploying will delete all of these existing files.  Continue?`;
                 let deleteAndDeploy: vscode.MessageItem = { title: 'Delete and Deploy' };
                 const result = await vscode.window.showWarningMessage(message, { modal: true }, deleteAndDeploy, DialogResponses.cancel);
                 if (result !== deleteAndDeploy) {
@@ -322,15 +329,39 @@ export class BlobContainerNode implements IAzureParentTreeItem, ICopyUrl {
             // Upload files as blobs
             await this.uploadFiles(sourceFolderPath, filePathsWithAzureSeparator, destBlobFolder, properties, updateProgress, cancellationToken);
 
-            ext.outputChannel.appendLine("Deployment to static website complete.");
+            let webEndpoint = this.getPrimaryWebEndpoint();
+            if (!webEndpoint) {
+                throw new Error(`Could not obtain the primary web endpoint for ${this.storageAccount.name}`);
+            }
+
+            ext.outputChannel.appendLine(`Deployment to static website complete. CTRL+Click to browse: ${webEndpoint}`);
+
+            return webEndpoint;
         } catch (error) {
             if (parseError(error).isUserCancelledError) {
                 ext.outputChannel.appendLine("Deployment canceled.");
-                throw error;
             }
+            throw error;
         }
     }
 
+    public getPrimaryWebEndpoint(): string | undefined {
+        // Right now we only support only web endpoint per storage account
+        return this.storageAccount.primaryEndpoints.web;
+    }
+
+    public getStorageAccountNode(node: IAzureNode<IAzureTreeItem>): IAzureParentNode<StorageAccountNode> {
+        if (!(node.treeItem instanceof BlobContainerNode)) {
+            throw new Error(`Unexpected node type: ${node.treeItem.contextValue}`);
+        }
+
+        let storageAccountNode = node.parent && node.parent.parent;
+        if (storageAccountNode && storageAccountNode.treeItem instanceof StorageAccountNode) {
+            return <IAzureParentNode<StorageAccountNode>>storageAccountNode;
+        } else {
+            throw new Error("Couldn't find storage account node for container");
+        }
+    }
     private async uploadFiles(
         sourceFolderPath: string,
         filePathsWithAzureSeparator: string[],

--- a/src/azureStorageExplorer/selectStorageAccountNodeForCommand.ts
+++ b/src/azureStorageExplorer/selectStorageAccountNodeForCommand.ts
@@ -43,7 +43,7 @@ export async function selectStorageAccountNodeForCommand(
 
     if (options.mustBeWebsiteCapable) {
         let hostingStatus = await accountNode.treeItem.getWebsiteHostingStatus();
-        await accountNode.treeItem.ensureHostingEnabled(hostingStatus);
+        await accountNode.treeItem.ensureHostingCapable(hostingStatus);
 
         if (options.askToConfigureWebsite && !hostingStatus.enabled) {
             let result = await window.showInformationMessage(

--- a/src/azureStorageExplorer/selectStorageAccountNodeForCommand.ts
+++ b/src/azureStorageExplorer/selectStorageAccountNodeForCommand.ts
@@ -1,0 +1,66 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { commands, window } from 'vscode';
+import { DialogResponses, IActionContext, IAzureNode, IAzureParentNode, IAzureTreeItem, UserCancelledError } from "vscode-azureextensionui";
+import { ext } from "../extensionVariables";
+import { BlobContainerNode } from "./blobContainers/blobContainerNode";
+import { StorageAccountNode } from "./storageAccounts/storageAccountNode";
+
+/**
+ * Given a node argument for a command, if it is:
+ *   1) undefined, then query the user for a storage account
+ *   2) a storage account node, then return it
+ *   3) a blob container node, then return the storage account node
+ *   4) anything else, then throw an internal error
+ */
+export async function selectStorageAccountNodeForCommand(
+    node: IAzureNode<IAzureTreeItem> | undefined,
+    actionContext: IActionContext,
+    options: { mustBeWebsiteCapable: boolean, askToConfigureWebsite: boolean }
+): Promise<IAzureParentNode<StorageAccountNode>> {
+    // Node should be one of:
+    //   undefined
+    //   a storage account node
+    //   a blob container node
+
+    let storageOrContainerNode = <IAzureNode<StorageAccountNode> | IAzureNode<BlobContainerNode>>node;
+    if (!storageOrContainerNode) {
+        storageOrContainerNode = <IAzureNode<StorageAccountNode>>await ext.tree.showNodePicker(StorageAccountNode.contextValue);
+    }
+
+    let accountNode: IAzureParentNode<StorageAccountNode>;
+    if (storageOrContainerNode.treeItem instanceof BlobContainerNode) {
+        // Currently the portal only allows configuring at the storage account level, so retrieve the storage account node
+        accountNode = storageOrContainerNode.treeItem.getStorageAccountNode(node);
+    } else if (storageOrContainerNode.treeItem instanceof StorageAccountNode) {
+        accountNode = <IAzureParentNode<StorageAccountNode>>storageOrContainerNode;
+    } else {
+        throw new Error(`Internal error: Unexpected node type: ${node.treeItem.contextValue}`);
+    }
+
+    if (options.mustBeWebsiteCapable) {
+        let hostingStatus = await accountNode.treeItem.getWebsiteHostingStatus();
+        await accountNode.treeItem.ensureHostingEnabled(hostingStatus);
+
+        if (options.askToConfigureWebsite && !hostingStatus.enabled) {
+            let result = await window.showInformationMessage(
+                `Website hosting is not enabled on storage account "${accountNode.treeItem.label}". Would you like to go to the portal to enable it?`,
+                DialogResponses.yes,
+                DialogResponses.no);
+            let enableResponse = (result === DialogResponses.yes);
+            actionContext.properties.enableResponse = String(enableResponse);
+            actionContext.properties.cancelStep = 'StorageAccountWebSiteNotEnabled';
+            if (enableResponse) {
+                await commands.executeCommand("azureStorage.configureStaticWebsite", accountNode);
+            }
+            // Either way can't continue
+            throw new UserCancelledError();
+
+        }
+    }
+
+    return accountNode;
+}

--- a/src/azureStorageExplorer/storageAccountProvider.ts
+++ b/src/azureStorageExplorer/storageAccountProvider.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 // tslint:disable-next-line:no-require-imports
-import StorageManagementClient = require('azure-arm-storage');
+import { StorageManagementClient } from 'azure-arm-storage';
 import { IAzureNode, IAzureTreeItem, IChildProvider } from 'vscode-azureextensionui';
 import { StorageAccount } from '../../node_modules/azure-arm-storage/lib/models';
 import { StorageAccountNode } from './storageAccounts/storageAccountNode';

--- a/src/azureStorageExplorer/storageAccounts/storageAccountNode.ts
+++ b/src/azureStorageExplorer/storageAccounts/storageAccountNode.ts
@@ -135,7 +135,7 @@ export class StorageAccountNode implements IAzureParentTreeItem {
         return result;
     }
 
-    public async getWebsiteCapableContainer(node: IAzureParentNode<StorageAccountNode>): Promise<IAzureParentNode<BlobContainerNode>> {
+    public async getWebsiteCapableContainer(node: IAzureParentNode<StorageAccountNode>): Promise<IAzureParentNode<BlobContainerNode> | undefined> {
         assert(node.treeItem === this);
 
         // Refresh the storage account first to make sure $web has been picked up if new
@@ -151,7 +151,7 @@ export class StorageAccountNode implements IAzureParentTreeItem {
 
     // This is the URL to use for browsing the website
     public getPrimaryWebEndpoint(): string | undefined {
-        // Right now we only support only web endpoint per storage account
+        // Right now Azure only supports one web endpoint per storage account
         return this.storageAccount.primaryEndpoints.web;
     }
 

--- a/src/azureStorageExplorer/storageAccounts/storageAccountNode.ts
+++ b/src/azureStorageExplorer/storageAccounts/storageAccountNode.ts
@@ -197,7 +197,7 @@ export class StorageAccountNode implements IAzureParentTreeItem {
     public async configureStaticWebsite(node: IAzureNode): Promise<void> {
         assert(node.treeItem === this);
         let hostingStatus = await this.getWebsiteHostingStatus();
-        await this.ensureHostingEnabled(hostingStatus);
+        await this.ensureHostingCapable(hostingStatus);
 
         let resourceId = `${node.id}/staticWebsite`;
         node.openInPortal(resourceId);
@@ -210,7 +210,7 @@ export class StorageAccountNode implements IAzureParentTreeItem {
         };
 
         let hostingStatus = await this.getWebsiteHostingStatus();
-        await this.ensureHostingEnabled(hostingStatus);
+        await this.ensureHostingCapable(hostingStatus);
 
         if (!hostingStatus.enabled) {
             let msg = "Static website hosting is not enabled for this storage account.";
@@ -238,7 +238,7 @@ export class StorageAccountNode implements IAzureParentTreeItem {
         }
     }
 
-    public async ensureHostingEnabled(hostingStatus: WebsiteHostingStatus): Promise<void> {
+    public async ensureHostingCapable(hostingStatus: WebsiteHostingStatus): Promise<void> {
         if (!hostingStatus.capable) {
             // Doesn't support static website hosting. Try to narrow it down.
             let accountType: StorageTypes;

--- a/src/azureStorageExplorer/storageAccounts/storageAccountNode.ts
+++ b/src/azureStorageExplorer/storageAccounts/storageAccountNode.ts
@@ -3,20 +3,30 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as assert from 'assert';
+import { StorageManagementClient } from 'azure-arm-storage';
+import * as azureStorage from "azure-storage";
 // tslint:disable-next-line:no-require-imports
-// tslint:disable-next-line:no-require-imports
-import StorageManagementClient = require('azure-arm-storage');
+import opn = require('opn');
 import * as path from 'path';
-import { Uri } from 'vscode';
+import { commands, MessageItem, Uri, window } from 'vscode';
+import { IAzureNode, IAzureParentNode, IAzureParentTreeItem, IAzureTreeItem, UserCancelledError } from 'vscode-azureextensionui';
 import { StorageAccount, StorageAccountKey } from '../../../node_modules/azure-arm-storage/lib/models';
 import * as ext from "../../constants";
 import { BlobContainerGroupNode } from '../blobContainers/blobContainerGroupNode';
-
-import { IAzureNode, IAzureParentNode, IAzureParentTreeItem, IAzureTreeItem } from 'vscode-azureextensionui';
 import { BlobContainerNode } from "../blobContainers/blobContainerNode";
 import { FileShareGroupNode } from '../fileShares/fileShareGroupNode';
 import { QueueGroupNode } from '../queues/queueGroupNode';
 import { TableGroupNode } from '../tables/tableGroupNode';
+
+export type WebsiteHostingStatus = {
+    capable: boolean;
+    enabled: boolean;
+    indexDocument: string;
+    errorDocument404Path: string;
+};
+
+type StorageTypes = 'Storage' | 'StorageV2' | 'BlobStorage';
 
 export class StorageAccountNode implements IAzureParentTreeItem {
     constructor(
@@ -125,12 +135,123 @@ export class StorageAccountNode implements IAzureParentTreeItem {
         return result;
     }
 
-    public async getWebsiteEnabledContainers(node: IAzureParentNode<StorageAccountNode>): Promise<IAzureParentNode<BlobContainerNode>[]> {
+    public async getWebsiteCapableContainer(node: IAzureParentNode<StorageAccountNode>): Promise<IAzureParentNode<BlobContainerNode>> {
+        assert(node.treeItem === this);
+
+        // Refresh the storage account first to make sure $web has been picked up if new
+        await node.refresh();
+
         let groupTreeItem = <IAzureTreeItem>await this.getBlobContainerGroupNode();
 
         // Currently only the child with the name "$web" is supported for hosting websites
         let id = `${this.id}/${groupTreeItem.id || groupTreeItem.label}/${ext.staticWebsiteContainerName}`;
         let containerNode = <IAzureParentNode<BlobContainerNode>>await node.treeDataProvider.findNode(id);
-        return containerNode ? [containerNode] : [];
+        return containerNode;
+    }
+
+    // This is the URL to use for browsing the website
+    public getPrimaryWebEndpoint(): string | undefined {
+        // Right now we only support only web endpoint per storage account
+        return this.storageAccount.primaryEndpoints.web;
+    }
+
+    public async createBlobService(): Promise<azureStorage.BlobService> {
+        let primaryKey = await this.getPrimaryKey();
+        let blobService = azureStorage.createBlobService(this.storageAccount.name, primaryKey.value);
+        return blobService;
+    }
+
+    public async getWebsiteHostingStatus(): Promise<WebsiteHostingStatus> {
+        let blobService = await this.createBlobService();
+
+        return await new Promise<WebsiteHostingStatus>((resolve, reject) => {
+            blobService.getServiceProperties((err, result: azureStorage.common.models.ServicePropertiesResult.BlobServiceProperties) => {
+                if (err) {
+                    reject(err);
+                } else {
+                    resolve({
+                        capable: !!result.StaticWebsite,
+                        enabled: result.StaticWebsite && result.StaticWebsite.Enabled,
+                        indexDocument: result.StaticWebsite && result.StaticWebsite.IndexDocument,
+                        errorDocument404Path: result.StaticWebsite && result.StaticWebsite.ErrorDocument404Path
+                    });
+                }
+            });
+        });
+
+    }
+
+    private async getAccountType(): Promise<StorageTypes> {
+        let blobService = await this.createBlobService();
+        return await new Promise<StorageTypes>((resolve, reject) => {
+            blobService.getAccountProperties(undefined, undefined, undefined, (err, result) => {
+                if (err) {
+                    reject(err);
+                } else {
+                    resolve(<StorageTypes>result.AccountKind);
+                }
+            });
+        });
+    }
+
+    public async configureStaticWebsite(node: IAzureNode): Promise<void> {
+        assert(node.treeItem === this);
+        let hostingStatus = await this.getWebsiteHostingStatus();
+        await this.ensureHostingEnabled(hostingStatus);
+
+        let resourceId = `${node.id}/staticWebsite`;
+        node.openInPortal(resourceId);
+    }
+
+    public async browseStaticWebsite(node: IAzureNode): Promise<void> {
+        assert(node.treeItem === this);
+        const configure: MessageItem = {
+            title: "Configure website hosting"
+        };
+
+        let hostingStatus = await this.getWebsiteHostingStatus();
+        await this.ensureHostingEnabled(hostingStatus);
+
+        if (!hostingStatus.enabled) {
+            let msg = "Static website hosting is not enabled for this storage account.";
+            let result = await window.showErrorMessage(msg, configure);
+            if (result === configure) {
+                await commands.executeCommand('azureStorage.configureStaticWebsite', node);
+            }
+            throw new UserCancelledError(msg);
+        }
+
+        if (!hostingStatus.indexDocument) {
+            let msg = "No index document has been set for this website.";
+            let result = await window.showErrorMessage(msg, configure);
+            if (result === configure) {
+                await commands.executeCommand('azureStorage.configureStaticWebsite', node);
+            }
+            throw new UserCancelledError(msg);
+        }
+
+        let endpoint = this.getPrimaryWebEndpoint();
+        if (endpoint) {
+            await opn(endpoint);
+        } else {
+            throw new Error(`Could not retrieve the primary web endpoint for ${this.label}`);
+        }
+    }
+
+    public async ensureHostingEnabled(hostingStatus: WebsiteHostingStatus): Promise<void> {
+        if (!hostingStatus.capable) {
+            // Doesn't support static website hosting. Try to narrow it down.
+            let accountType: StorageTypes;
+            try {
+                accountType = await this.getAccountType();
+            } catch (error) {
+                // Ignore errors
+            }
+            if (accountType !== 'StorageV2') {
+                throw new Error("Only general purpose V2 storage accounts support static website hosting.");
+            }
+
+            throw new Error("This storage account does not support static website hosting.");
+        }
     }
 }

--- a/src/extensionVariables.ts
+++ b/src/extensionVariables.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ExtensionContext, OutputChannel } from "vscode";
-import { IAzureUserInput } from "vscode-azureextensionui";
+import { AzureTreeDataProvider, IAzureUserInput } from "vscode-azureextensionui";
 import TelemetryReporter from "vscode-extension-telemetry";
 
 /**
@@ -15,4 +15,5 @@ export namespace ext {
     export let outputChannel: OutputChannel;
     export let ui: IAzureUserInput;
     export let reporter: TelemetryReporter;
+    export let tree: AzureTreeDataProvider;
 }

--- a/thirdpartynotices.txt
+++ b/thirdpartynotices.txt
@@ -9,6 +9,7 @@ are grateful to these developers for their contribution to open source.
 2. fs-extra (https://github.com/jprichardson/node-fs-extra)
 3. copy-paste (https://github.com/xavi-/node-copy-paste)
 4. glob (https://github.com/isaacs/node-glob)
+5. opn (https://github.com/sindresorhus/opn)
 
 node-winreg NOTICES BEGIN HERE
 =============================
@@ -91,6 +92,12 @@ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
 WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
 ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+END OF glob NOTICES AND INFORMATION
+==================================
+
+opn NOTICES BEGIN HERE
+=============================
 
 END OF glob NOTICES AND INFORMATION
 ==================================


### PR DESCRIPTION
Use new SDK functionality to:
- Add "Browse Static Website…", fixes #152
- Allow browsing after deploy (rather than asking them to go to portal)
- Ensure storage account can support hosted websites when deploying, browsing etc. (e.g. must be a V2 storage account), fixes #174, fixes #175
- Ensure storage account has hosted websites enabled when deploying, etc., and if not, ask if they want to configure
- Ensure website hosting has an index document set when browsing, and if not, ask if they want to - configure (fixes portal stupidity)