### PR TITLE
Remove direct dependency on telemetry package

### DIFF
--- a/package.json
+++ b/package.json
@@ -711,7 +711,6 @@
 		"ms-rest-azure": "^2.3.1",
 		"opn": "^5.3.0",
 		"vscode-azureextensionui": "^0.18.0",
-		"vscode-extension-telemetry": "^0.0.22",
 		"winreg": "^1.2.3"
 	}
 }


### PR DESCRIPTION
This repo is already using createTelemetryReporter from the shared package so there's no need to have the direct dependency here.

Fixes #242 