### PR TITLE
Improve activate method

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "vscode-azurestorage",
 	"displayName": "Azure Storage",
 	"description": "Manage your Azure Storage accounts including Blob Containers, File Shares, Tables and Queues",
-	"version": "0.4.2",
+	"version": "0.4.3-alpha",
 	"publisher": "ms-azuretools",
 	"aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
 	"engines": {
@@ -714,7 +714,7 @@
 		"ms-rest": "^2.2.2",
 		"ms-rest-azure": "^2.3.1",
 		"opn": "^5.3.0",
-		"vscode-azureextensionui": "^0.18.0",
+		"vscode-azureextensionui": "^0.19.2",
 		"winreg": "^1.2.3"
 	}
 }

--- a/tslint.json
+++ b/tslint.json
@@ -1,48 +1,13 @@
 {
+    "extends": "tslint-microsoft-contrib",
     "rules": {
-        "insecure-random": true,
-        "no-banned-terms": true,
-        "no-cookies": true,
-        "no-delete-expression": true,
-        "no-disable-auto-sanitization": true,
-        "no-document-domain": true,
-        "no-document-write": true,
-        "no-eval": true,
-        "no-exec-script": true,
-        "no-function-constructor-with-string-args": true,
-        "no-http-string": [
-            true,
-            "http://www.example.com/?.*",
-            "http://www.examples.com/?.*"
-        ],
-        "no-inner-html": true,
-        "no-octal-literal": true,
-        "no-reserved-keywords": true,
-        "no-string-based-set-immediate": true,
-        "no-string-based-set-interval": true,
-        "no-string-based-set-timeout": true,
-        "non-literal-require": true,
-        "possible-timing-attack": true,
-        "react-anchor-blank-noopener": true,
-        "react-iframe-missing-sandbox": true,
-        "react-no-dangerous-html": true,
         "await-promise": [
             true,
-            "Thenable" // changed
+            "Thenable"
         ],
-        "forin": true,
-        "jquery-deferred-must-complete": true,
-        "label-position": true,
-        "match-default-export-name": true,
-        "mocha-avoid-only": true,
-        "mocha-no-side-effect-code": true,
-        "no-any": true,
-        "no-arg": true,
-        "no-backbone-get-set-outside-model": false, // changed
-        "no-bitwise": true,
-        "no-conditional-assignment": true,
+        "no-backbone-get-set-outside-model": false,
         "no-console": [
-            false, // changed
+            false,
             "debug",
             "info",
             "log",
@@ -50,254 +15,79 @@
             "timeEnd",
             "trace"
         ],
-        "no-constant-condition": true,
-        "no-control-regex": true,
-        "no-debugger": true,
-        "no-duplicate-case": true,
-        "no-duplicate-super": true,
-        "no-duplicate-variable": true,
-        "no-empty": true,
-        "no-floating-promises": true,
-        "no-for-in-array": true,
-        "no-import-side-effect": true,
-        "no-increment-decrement": false, // changed
-        "no-invalid-regexp": true,
-        "no-invalid-template-strings": true,
-        "no-invalid-this": true,
-        "no-jquery-raw-elements": true,
-        "no-misused-new": true,
-        "no-non-null-assertion": true,
-        "no-reference-import": true,
-        "no-regex-spaces": true,
-        "no-sparse-arrays": true,
-        "no-stateless-class": true,
-        "no-string-literal": true,
-        "no-string-throw": true,
-        "no-unnecessary-bind": true,
-        "no-unnecessary-callback-wrapper": true,
-        "no-unnecessary-initializer": true,
-        "no-unnecessary-override": true,
-        "no-unsafe-any": true,
-        "no-unsafe-finally": true,
-        "no-unused-expression": true,
-        "no-use-before-declare": true,
-        "no-with-statement": true,
-        "promise-function-async": true,
-        "promise-must-complete": true,
-        "radix": true,
-        "react-this-binding-issue": true,
-        "react-unused-props-and-state": true,
-        "restrict-plus-operands": true,
+        "no-increment-decrement": false,
         "strict-boolean-expressions": [
             true,
-            "allow-string", // changed
-            "allow-undefined-union", // changed
-            "allow-null-union", // changed
-            "allow-mix", // changed
-            "allow-number" // changed
+            "allow-string",
+            "allow-undefined-union",
+            "allow-null-union",
+            "allow-mix",
+            "allow-number"
         ],
-        "switch-default": true,
-        "triple-equals": [
-            true,
-            "allow-null-check"
-        ],
-        "use-isnan": true,
-        "use-named-parameter": true,
-        "valid-typeof": true,
-        "adjacent-overload-signatures": true,
-        "array-type": [
-            true,
-            "array"
-        ],
-        "arrow-parens": false,
-        "callable-types": true,
-        "chai-prefer-contains-to-index-of": true,
-        "chai-vague-errors": true,
-        "class-name": true,
-        "comment-format": true,
         "completed-docs": [
-            false, // changed
+            false,
             "classes"
         ],
-        "export-name": false, // changed
+        "export-name": false,
         "function-name": [
             true,
             {
-                "method-regex": "^[a-z][\\w\\d]+$",
-                "private-method-regex": "^[a-z][\\w\\d]+$",
-                "protected-method-regex": "^[a-z][\\w\\d]+$",
-                "static-method-regex": "^[a-z][\\w_]+$", // changed
-                "function-regex": "^[a-z][\\w\\d]+$"
+                "static-method-regex": "^[a-z][\\w_]+$"
             }
         ],
-        "import-name": false, // changed
-        "interface-name": true,
-        "jsdoc-format": true,
-        "max-classes-per-file": [
-            true,
-            3
-        ],
-        "max-file-line-count": true,
-        "max-func-body-length": [
-            true,
-            100,
-            {
-                "ignore-parameters-to-function-regex": "describe"
-            }
-        ],
+        "import-name": false,
         "max-line-length": [
-            false, // changed
+            false,
             140
         ],
         "member-access": false,
         "member-ordering": [
-            false, // changed
+            false,
             {
                 "order": "fields-first"
             }
         ],
-        "missing-jsdoc": false, // changed
-        "mocha-unneeded-done": true,
-        "new-parens": true,
-        "no-construct": true,
-        "no-default-export": true,
-        "no-empty-interface": true,
-        "no-for-in": true,
-        "no-function-expression": true,
-        "no-inferrable-types": false,
-        "no-multiline-string": true,
-        "no-null-keyword": false,
-        "no-parameter-properties": false, // changed
-        "no-relative-imports": false, // changed
-        "no-require-imports": true,
-        "no-shadowed-variable": true,
-        "no-suspicious-comment": true,
-        "no-typeof-undefined": true,
-        "no-unnecessary-field-initialization": true,
-        "no-unnecessary-local-variable": false, // changed
-        "no-unnecessary-qualifier": true,
-        "no-unsupported-browser-code": true,
-        "no-useless-files": true,
-        "no-var-keyword": true,
-        "no-var-requires": true,
-        "no-var-self": true,
+        "missing-jsdoc": false,
+        "no-parameter-properties": false,
+        "no-relative-imports": false,
+        "no-unnecessary-local-variable": false,
         "no-void-expression": [
             true,
-            "ignore-arrow-function-shorthand" // changed
+            "ignore-arrow-function-shorthand"
         ],
-        "object-literal-sort-keys": false,
-        "one-variable-per-declaration": true,
-        "only-arrow-functions": false,
-        "ordered-imports": true,
-        "prefer-array-literal": true,
-        "prefer-const": false, // changed
-        "prefer-for-of": true,
-        "prefer-method-signature": true,
-        "prefer-template": true,
-        "return-undefined": false,
+        "prefer-const": false,
         "typedef": [
             true,
             "call-signature",
-            // "arrow-call-signature", // changed
+            // "arrow-call-signature",
             "parameter",
-            // "arrow-parameter", // changed
+            // "arrow-parameter",
             "property-declaration",
-            // "variable-declaration", //changed
+            // "variable-declaration",
             "member-variable-declaration"
         ],
-        "underscore-consistent-invocation": true,
-        "unified-signatures": true,
-        "variable-name": [ // changed
+        "variable-name": [
             true,
             "ban-keywords",
             "check-format",
             "allow-leading-underscore"
         ],
-        "react-a11y-anchors": true,
-        "react-a11y-aria-unsupported-elements": true,
-        "react-a11y-event-has-role": true,
-        "react-a11y-image-button-has-alt": true,
-        "react-a11y-img-has-alt": true,
-        "react-a11y-lang": true,
-        "react-a11y-meta": true,
-        "react-a11y-props": true,
-        "react-a11y-proptypes": true,
-        "react-a11y-role": true,
-        "react-a11y-role-has-required-aria-props": true,
-        "react-a11y-role-supports-aria-props": true,
-        "react-a11y-tabindex-no-positive": true,
-        "react-a11y-titles": true,
-        "align": [
-            true,
-            "parameters",
-            "arguments",
-            "statements"
-        ],
-        "curly": true,
-        "eofline": true,
-        "import-spacing": true,
-        "indent": [
-            true,
-            "spaces"
-        ],
-        "linebreak-style": false, // changed
-        "newline-before-return": false, // changed
-        "no-consecutive-blank-lines": true,
-        "no-empty-line-after-opening-brace": false,
-        "no-single-line-block-comment": false, // changed
-        "no-trailing-whitespace": true,
-        "no-unnecessary-semicolons": true,
-        "object-literal-key-quotes": [
-            true,
-            "as-needed"
-        ],
-        "one-line": [
-            true,
-            "check-open-brace",
-            "check-catch",
-            "check-else",
-            "check-whitespace"
-        ],
+        "linebreak-style": false,
+        "newline-before-return": false,
+        "no-single-line-block-comment": false,
         "quotemark": [
-            false, // changed
+            false,
             "single"
-        ],
-        "react-tsx-curly-spacing": true,
-        "semicolon": [
-            true,
-            "always"
         ],
         "trailing-comma": [
             true,
             {
                 "singleline": "never",
-                "multiline": "ignore" // changed
+                "multiline": "ignore"
             }
         ],
-        "typedef-whitespace": false,
-        "whitespace": [
-            true,
-            "check-branch",
-            "check-decl",
-            "check-operator",
-            "check-separator",
-            "check-type"
-        ],
-        "ban": false,
-        "ban-types": true,
-        "cyclomatic-complexity": true,
-        "file-header": false,
-        "import-blacklist": false,
-        "interface-over-type-literal": false,
-        "no-angle-bracket-type-assertion": false,
-        "no-inferred-empty-object-type": false,
-        "no-internal-module": false,
-        "no-magic-numbers": false,
-        "no-mergeable-namespace": false,
-        "no-namespace": false,
-        "no-reference": true,
-        "no-unexternalized-strings": [ // changed
-            false, // changed
+        "no-unexternalized-strings": [
+            false,
             {
                 "signatures": [
                     "localize",
@@ -306,17 +96,6 @@
                 "keyIndex": 0,
                 "messageIndex": 1
             }
-        ],
-        "object-literal-shorthand": false,
-        "prefer-type-cast": true,
-        "space-before-function-paren": false,
-        "missing-optional-annotation": false,
-        "no-duplicate-parameter-names": false,
-        "no-empty-interfaces": false,
-        "no-missing-visibility-modifiers": false,
-        "no-multiple-var-decl": false,
-        "no-switch-case-fall-through": false,
-        "typeof-compare": false
-    },
-    "rulesDirectory": "node_modules/tslint-microsoft-contrib/"
+        ]
+    }
 }


### PR DESCRIPTION
!!Review with whitespace off!! lol

- Leverage latest UI package (which had breaking changes related to ordering of `registerUIExtensionVariables`)
- Add basic perf telemetry
- Return empty `AzureExtensionApiProvider` (The sooner we get the api provider in - the sooner it can start working it's versioning magic going forward.)

Other cleanup:
- add 'alpha' to version
- Refactor "tslint.json" to use "extends" instead of copying all rules. No actual changes to the rules with this PR