### PR TITLE
Add support for command palette

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -29,5 +29,6 @@
         ".vscode-test/**": true,
         "out": false, // set this to true to hide the "out" folder with the compiled JS files
         ".vscode-test": true
-    }
+    },
+    "typescript.preferences.importModuleSpecifier": "relative"
 }

--- a/package.json
+++ b/package.json
@@ -91,11 +91,13 @@
 				"icon": {
 					"light": "resources/light/refresh.svg",
 					"dark": "resources/dark/refresh.svg"
-				}
+				},
+				"category": "Azure Storage"
 			},
 			{
 				"command": "azureStorage.openInPortal",
-				"title": "Open in Portal"
+				"title": "Open in Portal",
+				"category": "Azure Storage"
 			},
 			{
 				"command": "azureStorage.configureStaticWebsite",
@@ -104,7 +106,7 @@
 			},
 			{
 				"command": "azureStorage.browseStaticWebsite",
-				"title": "Browse Static Website...",
+				"title": "Browse Static Website",
 				"category": "Azure Storage"
 			},
 			{
@@ -113,7 +115,8 @@
 				"icon": {
 					"light": "resources/light/filter.svg",
 					"dark": "resources/dark/filter.svg"
-				}
+				},
+				"category": "Azure Storage"
 			},
 			{
 				"command": "azureStorage.deployStaticWebsite",
@@ -126,103 +129,128 @@
 			},
 			{
 				"command": "azureStorage.copyUrl",
-				"title": "Copy URL"
+				"title": "Copy URL",
+				"category": "Azure Storage"
 			},
 			{
 				"command": "azureStorage.openBlobContainer",
-				"title": "Open in Storage Explorer"
+				"title": "Open in Storage Explorer",
+				"category": "Azure Storage"
 			},
 			{
 				"command": "azureStorage.openTable",
-				"title": "Open in Storage Explorer"
+				"title": "Open in Storage Explorer",
+				"category": "Azure Storage"
 			},
 			{
 				"command": "azureStorage.openFileShare",
-				"title": "Open in Storage Explorer"
+				"title": "Open in Storage Explorer",
+				"category": "Azure Storage"
 			},
 			{
 				"command": "azureStorage.openQueue",
-				"title": "Open in Storage Explorer"
+				"title": "Open in Storage Explorer",
+				"category": "Azure Storage"
 			},
 			{
 				"command": "azureStorage.openStorageAccount",
-				"title": "Open in Storage Explorer"
+				"title": "Open in Storage Explorer",
+				"category": "Azure Storage"
 			},
 			{
 				"command": "azureStorage.copyPrimaryKey",
-				"title": "Copy Primary Key"
+				"title": "Copy Primary Key",
+				"category": "Azure Storage"
 			},
 			{
 				"command": "azureStorage.copyConnectionString",
-				"title": "Copy Connection String"
+				"title": "Copy Connection String",
+				"category": "Azure Storage"
 			},
 			{
 				"command": "azureStorage.createBlobContainer",
-				"title": "Create Blob Container"
+				"title": "Create Blob Container...",
+				"category": "Azure Storage"
 			},
 			{
 				"command": "azureStorage.deleteBlobContainer",
-				"title": "Delete Blob Container"
+				"title": "Delete Blob Container...",
+				"category": "Azure Storage"
 			},
 			{
 				"command": "azureStorage.createBlockTextBlob",
-				"title": "Create Empty Text Blob"
+				"title": "Create Empty Text Blob...",
+				"category": "Azure Storage"
 			},
 			{
 				"command": "azureStorage.uploadBlockBlob",
-				"title": "Upload Block Blob..."
+				"title": "Upload Block Blob...",
+				"category": "Azure Storage"
 			},
 			{
 				"command": "azureStorage.deleteBlob",
-				"title": "Delete"
+				"title": "Delete...",
+				"category": "Azure Storage"
 			},
 			{
 				"command": "azureStorage.downloadBlob",
-				"title": "Download..."
+				"title": "Download...",
+				"category": "Azure Storage"
 			},
 			{
 				"command": "azureStorage.createFileShare",
-				"title": "Create File Share"
+				"title": "Create File Share...",
+				"category": "Azure Storage"
 			},
 			{
 				"command": "azureStorage.deleteFileShare",
-				"title": "Delete File Share"
+				"title": "Delete File Share...",
+				"category": "Azure Storage"
 			},
 			{
 				"command": "azureStorage.createDirectory",
-				"title": "Create Directory"
+				"title": "Create Directory...",
+				"category": "Azure Storage"
 			},
 			{
 				"command": "azureStorage.createSubdirectory",
-				"title": "Create Subdirectory"
+				"title": "Create Subdirectory...",
+				"category": "Azure Storage"
 			},
 			{
 				"command": "azureStorage.deleteDirectory",
-				"title": "Delete Directory"
+				"title": "Delete Directory...",
+				"category": "Azure Storage"
 			},
 			{
 				"command": "azureStorage.createTextFile",
-				"title": "Create Empty Text File"
+				"title": "Create Empty Text File...",
+				"category": "Azure Storage"
 			},
 			{
 				"command": "azureStorage.deleteFile",
-				"title": "Delete"
+				"title": "Delete...",
+				"category": "Azure Storage"
 			},
 			{
 				"command": "azureStorage.createTable",
-				"title": "Create Table"
+				"title": "Create Table...",
+				"category": "Azure Storage"
 			},
 			{
 				"command": "azureStorage.deleteTable",
-				"title": "Delete Table"
+				"title": "Delete Table...",
+				"category": "Azure Storage"
 			},
 			{
 				"command": "azureStorage.createQueue",
-				"title": "Create Queue"
+				"title": "Create Queue...",
+				"category": "Azure Storage"
 			},
 			{
 				"command": "azureStorage.deleteQueue",
-				"title": "Delete Queue"
+				"title": "Delete Queue...",
+				"category": "Azure Storage"
 			}
 		],
 		"menus": {
@@ -512,14 +540,6 @@
 					"when": "never"
 				},
 				{
-					"command": "azureStorage.createBlobContainer",
-					"when": "never"
-				},
-				{
-					"command": "azureStorage.deleteBlobContainer",
-					"when": "never"
-				},
-				{
 					"command": "azureStorage.createBlockTextBlob",
 					"when": "never"
 				},
@@ -540,23 +560,7 @@
 					"when": "never"
 				},
 				{
-					"command": "azureStorage.createTable",
-					"when": "never"
-				},
-				{
-					"command": "azureStorage.deleteTable",
-					"when": "never"
-				},
-				{
 					"command": "azureStorage.openFileShare",
-					"when": "never"
-				},
-				{
-					"command": "azureStorage.createFileShare",
-					"when": "never"
-				},
-				{
-					"command": "azureStorage.deleteFileShare",
 					"when": "never"
 				},
 				{
@@ -582,39 +586,6 @@
 				{
 					"command": "azureStorage.openQueue",
 					"when": "never"
-				},
-				{
-					"command": "azureStorage.openStorageAccount",
-					"when": "never"
-				},
-				{
-					"command": "azureStorage.copyConnectionString",
-					"when": "never"
-				},
-				{
-					"command": "azureStorage.copyPrimaryKey",
-					"when": "never"
-				},
-				{
-					"command": "azureStorage.createQueue",
-					"when": "never"
-				},
-				{
-					"command": "azureStorage.deleteQueue",
-					"when": "never"
-				},
-				{
-					"command": "azureStorage.openInPortal",
-					"when": "never"
-				},
-				{
-					"command": "azureStorage.configureStaticWebsite"
-				},
-				{
-					"command": "azureStorage.deployStaticWebsite"
-				},
-				{
-					"command": "azureStorage.browseStaticWebsite"
 				}
 			]
 		},

--- a/package.json
+++ b/package.json
@@ -189,7 +189,7 @@
 			},
 			{
 				"command": "azureStorage.deleteBlob",
-				"title": "Delete...",
+				"title": "Delete",
 				"category": "Azure Storage"
 			},
 			{
@@ -229,7 +229,7 @@
 			},
 			{
 				"command": "azureStorage.deleteFile",
-				"title": "Delete...",
+				"title": "Delete",
 				"category": "Azure Storage"
 			},
 			{

--- a/src/azureStorageExplorer/blobContainers/blobContainerActionHandlers.ts
+++ b/src/azureStorageExplorer/blobContainers/blobContainerActionHandlers.ts
@@ -9,6 +9,7 @@ import { IActionContext, registerCommand, registerEvent } from 'vscode-azureexte
 import { RemoteFileEditor } from '../../azureServiceExplorer/editors/RemoteFileEditor';
 import { ext } from '../../extensionVariables';
 import { storageExplorerLauncher } from '../../storageExplorerLauncher/storageExplorerLauncher';
+import { deleteNode } from '../commonTreeCommands';
 import { BlobContainerTreeItem, ChildType } from './blobContainerNode';
 import { BlobFileHandler } from './blobFileHandler';
 import { BlobTreeItem } from './blobNode';
@@ -19,7 +20,7 @@ export function registerBlobContainerActionHandlers(): void {
 
     registerCommand("azureStorage.openBlobContainer", openBlobContainerInStorageExplorer);
     registerCommand("azureStorage.editBlob", async (treeItem: BlobTreeItem) => await _editor.showEditor(treeItem));
-    registerCommand("azureStorage.deleteBlobContainer", async (treeItem: BlobContainerTreeItem) => await treeItem.deleteTreeItem());
+    registerCommand("azureStorage.deleteBlobContainer", async (treeItem?: BlobContainerTreeItem) => await deleteNode(BlobContainerTreeItem.contextValue, treeItem));
     registerCommand("azureStorage.createBlockTextBlob", async (treeItem: BlobContainerTreeItem) => {
         let childTreeItem = await treeItem.createChild({ childType: ChildType.newBlockBlob });
         await vscode.commands.executeCommand("azureStorage.editBlob", childTreeItem);

--- a/src/azureStorageExplorer/blobContainers/blobContainerGroupActionHandlers.ts
+++ b/src/azureStorageExplorer/blobContainers/blobContainerGroupActionHandlers.ts
@@ -4,8 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { registerCommand } from 'vscode-azureextensionui';
+import { createChildNode } from '../commonTreeCommands';
 import { BlobContainerGroupTreeItem } from './blobContainerGroupNode';
 
 export function registerBlobContainerGroupActionHandlers(): void {
-    registerCommand("azureStorage.createBlobContainer", async (treeItem: BlobContainerGroupTreeItem) => await treeItem.createChild());
+    registerCommand("azureStorage.createBlobContainer", async (treeItem?: BlobContainerGroupTreeItem) => await createChildNode(BlobContainerGroupTreeItem.contextValue, treeItem));
 }

--- a/src/azureStorageExplorer/blobContainers/blobContainerGroupNode.ts
+++ b/src/azureStorageExplorer/blobContainers/blobContainerGroupNode.ts
@@ -15,7 +15,9 @@ export class BlobContainerGroupTreeItem extends AzureParentTreeItem<IStorageRoot
     private _continuationToken: azureStorage.common.ContinuationToken | undefined;
 
     public label: string = "Blob Containers";
-    public contextValue: string = 'azureBlobContainerGroup';
+    public readonly childTypeLabel: string = "Blob Container";
+    public static contextValue: string = 'azureBlobContainerGroup';
+    public contextValue: string = BlobContainerGroupTreeItem.contextValue;
     public iconPath: { light: string | Uri; dark: string | Uri } = {
         light: path.join(__filename, '..', '..', '..', '..', '..', 'resources', 'light', 'AzureBlobContainer.svg'),
         dark: path.join(__filename, '..', '..', '..', '..', '..', 'resources', 'dark', 'AzureBlobContainer.svg')

--- a/src/azureStorageExplorer/commonTreeCommands.ts
+++ b/src/azureStorageExplorer/commonTreeCommands.ts
@@ -1,0 +1,23 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { AzureParentTreeItem, AzureTreeItem } from 'vscode-azureextensionui';
+import { ext } from '../extensionVariables';
+
+export async function deleteNode(expectedContextValue: string, node?: AzureTreeItem): Promise<void> {
+    if (!node) {
+        node = await ext.tree.showTreeItemPicker(expectedContextValue);
+    }
+
+    await node.deleteTreeItem();
+}
+
+export async function createChildNode(expectedContextValue: string, node?: AzureParentTreeItem): Promise<void> {
+    if (!node) {
+        node = <AzureParentTreeItem>await ext.tree.showTreeItemPicker(expectedContextValue);
+    }
+
+    await node.createChild();
+}

--- a/src/azureStorageExplorer/fileShares/fileShareActionHandlers.ts
+++ b/src/azureStorageExplorer/fileShares/fileShareActionHandlers.ts
@@ -7,6 +7,7 @@ import { IActionContext, registerCommand, registerEvent } from 'vscode-azureexte
 import { RemoteFileEditor } from '../../azureServiceExplorer/editors/RemoteFileEditor';
 import { ext } from '../../extensionVariables';
 import { storageExplorerLauncher } from '../../storageExplorerLauncher/storageExplorerLauncher';
+import { deleteNode } from '../commonTreeCommands';
 import { DirectoryTreeItem } from './directoryNode';
 import { FileFileHandler } from './fileFileHandler';
 import { FileTreeItem } from './fileNode';
@@ -19,7 +20,7 @@ export function registerFileShareActionHandlers(): void {
 
     registerCommand("azureStorage.openFileShare", openFileShareInStorageExplorer);
     registerCommand("azureStorage.editFile", async (treeItem: FileTreeItem) => await _editor.showEditor(treeItem));
-    registerCommand("azureStorage.deleteFileShare", async (treeItem: FileShareTreeItem) => await treeItem.deleteTreeItem());
+    registerCommand("azureStorage.deleteFileShare", async (treeItem?: FileShareTreeItem) => await deleteNode(FileShareTreeItem.contextValue, treeItem));
     registerCommand("azureStorage.createDirectory", async (treeItem: FileShareTreeItem) => await treeItem.createChild(DirectoryTreeItem.contextValue));
     registerCommand("azureStorage.createTextFile", async (treeItem: FileShareTreeItem) => {
         let childTreeItem = await treeItem.createChild(FileTreeItem.contextValue);

--- a/src/azureStorageExplorer/fileShares/fileShareGroupActionHandlers.ts
+++ b/src/azureStorageExplorer/fileShares/fileShareGroupActionHandlers.ts
@@ -4,8 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { registerCommand } from 'vscode-azureextensionui';
+import { createChildNode } from '../commonTreeCommands';
 import { FileShareGroupTreeItem } from './fileShareGroupNode';
 
 export function registerFileShareGroupActionHandlers(): void {
-    registerCommand("azureStorage.createFileShare", async (treeItem: FileShareGroupTreeItem) => await treeItem.createChild());
+    registerCommand("azureStorage.createFileShare", async (treeItem?: FileShareGroupTreeItem) => await createChildNode(FileShareGroupTreeItem.contextValue, treeItem));
 }

--- a/src/azureStorageExplorer/fileShares/fileShareGroupNode.ts
+++ b/src/azureStorageExplorer/fileShares/fileShareGroupNode.ts
@@ -18,7 +18,9 @@ export class FileShareGroupTreeItem extends AzureParentTreeItem<IStorageRoot> {
     private _continuationToken: azureStorage.common.ContinuationToken | undefined;
 
     public label: string = "File Shares";
-    public contextValue: string = 'azureFileShareGroup';
+    public readonly childTypeLabel: string = "File Share";
+    public static contextValue: string = 'azureFileShareGroup';
+    public contextValue: string = FileShareGroupTreeItem.contextValue;
     public iconPath: { light: string | Uri; dark: string | Uri } = {
         light: path.join(__filename, '..', '..', '..', '..', '..', 'resources', 'light', 'AzureFileShare.svg'),
         dark: path.join(__filename, '..', '..', '..', '..', '..', 'resources', 'dark', 'AzureFileShare.svg')

--- a/src/azureStorageExplorer/fileShares/fileShareNode.ts
+++ b/src/azureStorageExplorer/fileShares/fileShareNode.ts
@@ -26,7 +26,8 @@ export class FileShareTreeItem extends AzureParentTreeItem<IStorageRoot> impleme
     }
 
     public label: string = this.share.name;
-    public contextValue: string = 'azureFileShare';
+    public static contextValue: string = 'azureFileShare';
+    public contextValue: string = FileShareTreeItem.contextValue;
     public iconPath: { light: string | Uri; dark: string | Uri } = {
         light: path.join(__filename, '..', '..', '..', '..', '..', 'resources', 'light', 'AzureFileShare.svg'),
         dark: path.join(__filename, '..', '..', '..', '..', '..', 'resources', 'dark', 'AzureFileShare.svg')

--- a/src/azureStorageExplorer/queues/queueActionHandlers.ts
+++ b/src/azureStorageExplorer/queues/queueActionHandlers.ts
@@ -5,11 +5,12 @@
 
 import { registerCommand } from 'vscode-azureextensionui';
 import { storageExplorerLauncher } from '../../storageExplorerLauncher/storageExplorerLauncher';
+import { deleteNode } from '../commonTreeCommands';
 import { QueueTreeItem } from './queueNode';
 
 export function registerQueueActionHandlers(): void {
     registerCommand("azureStorage.openQueue", openQueueInStorageExplorer);
-    registerCommand("azureStorage.deleteQueue", async (treeItem: QueueTreeItem) => await treeItem.deleteTreeItem());
+    registerCommand("azureStorage.deleteQueue", async (treeItem?: QueueTreeItem) => await deleteNode(QueueTreeItem.contextValue, treeItem));
 }
 
 // tslint:disable-next-line:promise-function-async // Grandfathered in

--- a/src/azureStorageExplorer/queues/queueGroupActionHandlers.ts
+++ b/src/azureStorageExplorer/queues/queueGroupActionHandlers.ts
@@ -4,8 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { registerCommand } from 'vscode-azureextensionui';
+import { createChildNode } from '../commonTreeCommands';
 import { QueueGroupTreeItem } from './queueGroupNode';
 
 export function registerQueueGroupActionHandlers(): void {
-    registerCommand("azureStorage.createQueue", async (treeItem: QueueGroupTreeItem) => await treeItem.createChild());
+    registerCommand("azureStorage.createQueue", async (treeItem?: QueueGroupTreeItem) => await createChildNode(QueueGroupTreeItem.contextValue, treeItem));
 }

--- a/src/azureStorageExplorer/queues/queueGroupNode.ts
+++ b/src/azureStorageExplorer/queues/queueGroupNode.ts
@@ -14,7 +14,9 @@ export class QueueGroupTreeItem extends AzureParentTreeItem<IStorageRoot> {
     private _continuationToken: azureStorage.common.ContinuationToken | undefined;
 
     public label: string = "Queues";
-    public contextValue: string = 'azureQueueGroup';
+    public readonly childTypeLabel: string = "Queue";
+    public static contextValue: string = 'azureQueueGroup';
+    public contextValue: string = QueueGroupTreeItem.contextValue;
     public iconPath: { light: string | Uri; dark: string | Uri } = {
         light: path.join(__filename, '..', '..', '..', '..', '..', 'resources', 'light', 'AzureQueue.svg'),
         dark: path.join(__filename, '..', '..', '..', '..', '..', 'resources', 'dark', 'AzureQueue.svg')

--- a/src/azureStorageExplorer/queues/queueNode.ts
+++ b/src/azureStorageExplorer/queues/queueNode.ts
@@ -17,7 +17,8 @@ export class QueueTreeItem extends AzureTreeItem<IStorageRoot> {
     }
 
     public label: string = this.queue.name;
-    public contextValue: string = 'azureQueue';
+    public static contextValue: string = 'azureQueue';
+    public contextValue: string = QueueTreeItem.contextValue;
     public iconPath: { light: string | Uri; dark: string | Uri } = {
         light: path.join(__filename, '..', '..', '..', '..', '..', 'resources', 'light', 'AzureQueue.svg'),
         dark: path.join(__filename, '..', '..', '..', '..', '..', 'resources', 'dark', 'AzureQueue.svg')

--- a/src/azureStorageExplorer/storageAccounts/storageAccountActionHandlers.ts
+++ b/src/azureStorageExplorer/storageAccounts/storageAccountActionHandlers.ts
@@ -8,6 +8,7 @@ import * as vscode from "vscode";
 import { IActionContext, registerCommand, TelemetryProperties } from 'vscode-azureextensionui';
 import { isPathEqual, isSubpath } from '../../components/fs';
 import { configurationSettingsKeys, extensionPrefix } from '../../constants';
+import { ext } from '../../extensionVariables';
 import { storageExplorerLauncher } from '../../storageExplorerLauncher/storageExplorerLauncher';
 import { BlobContainerTreeItem } from "../blobContainers/blobContainerNode";
 import { showWorkspaceFoldersQuickPick } from "../blobContainers/quickPickUtils";
@@ -21,17 +22,29 @@ export function registerStorageAccountActionHandlers(): void {
     registerCommand("azureStorage.deployStaticWebsite", deployStaticWebsite);
 }
 
-async function openStorageAccountInStorageExplorer(treeItem: StorageAccountTreeItem): Promise<void> {
+async function openStorageAccountInStorageExplorer(treeItem?: StorageAccountTreeItem): Promise<void> {
+    if (!treeItem) {
+        treeItem = <StorageAccountTreeItem>await ext.tree.showTreeItemPicker(StorageAccountTreeItem.contextValue);
+    }
+
     let accountId = treeItem.storageAccount.id;
 
     await storageExplorerLauncher.openResource(accountId, treeItem.root.subscriptionId);
 }
 
-async function copyPrimaryKey(treeItem: StorageAccountTreeItem): Promise<void> {
+async function copyPrimaryKey(treeItem?: StorageAccountTreeItem): Promise<void> {
+    if (!treeItem) {
+        treeItem = <StorageAccountTreeItem>await ext.tree.showTreeItemPicker(StorageAccountTreeItem.contextValue);
+    }
+
     await clipboardy.write(treeItem.key.value);
 }
 
-async function copyConnectionString(treeItem: StorageAccountTreeItem): Promise<void> {
+async function copyConnectionString(treeItem?: StorageAccountTreeItem): Promise<void> {
+    if (!treeItem) {
+        treeItem = <StorageAccountTreeItem>await ext.tree.showTreeItemPicker(StorageAccountTreeItem.contextValue);
+    }
+
     let connectionString = await treeItem.getConnectionString();
     await clipboardy.write(connectionString);
 }

--- a/src/azureStorageExplorer/storageAccounts/storageAccountNode.ts
+++ b/src/azureStorageExplorer/storageAccounts/storageAccountNode.ts
@@ -15,10 +15,15 @@ import { StorageAccountKeyWrapper, StorageAccountWrapper } from '../../component
 import * as ext from "../../constants";
 import { BlobContainerGroupTreeItem } from '../blobContainers/blobContainerGroupNode';
 import { BlobContainerTreeItem } from "../blobContainers/blobContainerNode";
+import { DirectoryTreeItem } from '../fileShares/directoryNode';
+import { FileTreeItem } from '../fileShares/fileNode';
 import { FileShareGroupTreeItem } from '../fileShares/fileShareGroupNode';
+import { FileShareTreeItem } from '../fileShares/fileShareNode';
 import { IStorageRoot } from '../IStorageRoot';
 import { QueueGroupTreeItem } from '../queues/queueGroupNode';
+import { QueueTreeItem } from '../queues/queueNode';
 import { TableGroupTreeItem } from '../tables/tableGroupNode';
+import { TableTreeItem } from '../tables/tableNode';
 
 export type WebsiteHostingStatus = {
     capable: boolean;
@@ -33,6 +38,9 @@ export class StorageAccountTreeItem extends AzureParentTreeItem<IStorageRoot> {
     public key: StorageAccountKeyWrapper;
 
     private readonly _blobContainerGroupTreeItem: BlobContainerGroupTreeItem;
+    private readonly _fileShareGroupTreeItem: FileShareGroupTreeItem;
+    private readonly _queueGroupTreeItem: QueueGroupTreeItem;
+    private readonly _tableGroupTreeItem: TableGroupTreeItem;
     private _root: IStorageRoot;
 
     private constructor(
@@ -42,6 +50,9 @@ export class StorageAccountTreeItem extends AzureParentTreeItem<IStorageRoot> {
         super(parent);
         this._root = this.createRoot(parent.root);
         this._blobContainerGroupTreeItem = new BlobContainerGroupTreeItem(this);
+        this._fileShareGroupTreeItem = new FileShareGroupTreeItem(this);
+        this._queueGroupTreeItem = new QueueGroupTreeItem(this);
+        this._tableGroupTreeItem = new TableGroupTreeItem(this);
     }
 
     public static async createStorageAccountTreeItem(parent: AzureParentTreeItem, storageAccount: StorageAccountWrapper, client: StorageManagementClient): Promise<StorageAccountTreeItem> {
@@ -73,18 +84,39 @@ export class StorageAccountTreeItem extends AzureParentTreeItem<IStorageRoot> {
         }
 
         if (!!primaryEndpoints.file) {
-            groupTreeItems.push(new FileShareGroupTreeItem(this));
+            groupTreeItems.push(this._fileShareGroupTreeItem);
         }
 
         if (!!primaryEndpoints.queue) {
-            groupTreeItems.push(new QueueGroupTreeItem(this));
+            groupTreeItems.push(this._queueGroupTreeItem);
         }
 
         if (!!primaryEndpoints.table) {
-            groupTreeItems.push(new TableGroupTreeItem(this));
+            groupTreeItems.push(this._tableGroupTreeItem);
         }
 
         return groupTreeItems;
+    }
+
+    public pickTreeItemImpl(expectedContextValue: string): AzureTreeItem<IStorageRoot> | undefined {
+        switch (expectedContextValue) {
+            case BlobContainerGroupTreeItem.contextValue:
+            case BlobContainerTreeItem.contextValue:
+                return this._blobContainerGroupTreeItem;
+            case FileShareGroupTreeItem.contextValue:
+            case FileShareTreeItem.contextValue:
+            case DirectoryTreeItem.contextValue:
+            case FileTreeItem.contextValue:
+                return this._fileShareGroupTreeItem;
+            case QueueGroupTreeItem.contextValue:
+            case QueueTreeItem.contextValue:
+                return this._queueGroupTreeItem;
+            case TableGroupTreeItem.contextValue:
+            case TableTreeItem.contextValue:
+                return this._tableGroupTreeItem;
+            default:
+                return undefined;
+        }
     }
 
     hasMoreChildrenImpl(): boolean {

--- a/src/azureStorageExplorer/tables/tableActionHandlers.ts
+++ b/src/azureStorageExplorer/tables/tableActionHandlers.ts
@@ -5,11 +5,12 @@
 
 import { registerCommand } from 'vscode-azureextensionui';
 import { storageExplorerLauncher } from '../../storageExplorerLauncher/storageExplorerLauncher';
+import { deleteNode } from '../commonTreeCommands';
 import { TableTreeItem } from './tableNode';
 
 export function registerTableActionHandlers(): void {
     registerCommand("azureStorage.openTable", openTableInStorageExplorer);
-    registerCommand("azureStorage.deleteTable", async (treeItem: TableTreeItem) => await treeItem.deleteTreeItem());
+    registerCommand("azureStorage.deleteTable", async (treeItem?: TableTreeItem) => await deleteNode(TableTreeItem.contextValue, treeItem));
 }
 
 // tslint:disable-next-line:promise-function-async // Grandfathered in

--- a/src/azureStorageExplorer/tables/tableGroupActionHandlers.ts
+++ b/src/azureStorageExplorer/tables/tableGroupActionHandlers.ts
@@ -4,8 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { registerCommand } from 'vscode-azureextensionui';
+import { createChildNode } from '../commonTreeCommands';
 import { TableGroupTreeItem } from './tableGroupNode';
 
 export function registerTableGroupActionHandlers(): void {
-    registerCommand("azureStorage.createTable", async (treeItem: TableGroupTreeItem) => await treeItem.createChild());
+    registerCommand("azureStorage.createTable", async (treeItem?: TableGroupTreeItem) => await createChildNode(TableGroupTreeItem.contextValue, treeItem));
 }

--- a/src/azureStorageExplorer/tables/tableGroupNode.ts
+++ b/src/azureStorageExplorer/tables/tableGroupNode.ts
@@ -15,7 +15,9 @@ export class TableGroupTreeItem extends AzureParentTreeItem<IStorageRoot> {
     private _continuationToken: azureStorage.TableService.ListTablesContinuationToken | undefined;
 
     public label: string = "Tables";
-    public contextValue: string = 'azureTableGroup';
+    public readonly childTypeLabel: string = "Table";
+    public static contextValue: string = 'azureTableGroup';
+    public contextValue: string = TableGroupTreeItem.contextValue;
     public iconPath: { light: string | Uri; dark: string | Uri } = {
         light: path.join(__filename, '..', '..', '..', '..', '..', 'resources', 'light', 'AzureTable.svg'),
         dark: path.join(__filename, '..', '..', '..', '..', '..', 'resources', 'dark', 'AzureTable.svg')

--- a/src/azureStorageExplorer/tables/tableNode.ts
+++ b/src/azureStorageExplorer/tables/tableNode.ts
@@ -16,7 +16,8 @@ export class TableTreeItem extends AzureTreeItem<IStorageRoot> {
     }
 
     public label: string = this.tableName;
-    public contextValue: string = 'azureTable';
+    public static contextValue: string = 'azureTable';
+    public contextValue: string = TableTreeItem.contextValue;
     public iconPath: { light: string | Uri; dark: string | Uri } = {
         light: path.join(__filename, '..', '..', '..', '..', '..', 'resources', 'light', 'AzureTable.svg'),
         dark: path.join(__filename, '..', '..', '..', '..', '..', 'resources', 'dark', 'AzureTable.svg')

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,6 +25,7 @@ import { registerQueueGroupActionHandlers } from './azureStorageExplorer/queues/
 import { selectStorageAccountTreeItemForCommand } from './azureStorageExplorer/selectStorageAccountNodeForCommand';
 import { StorageAccountProvider } from './azureStorageExplorer/storageAccountProvider';
 import { registerStorageAccountActionHandlers } from './azureStorageExplorer/storageAccounts/storageAccountActionHandlers';
+import { StorageAccountTreeItem } from './azureStorageExplorer/storageAccounts/storageAccountNode';
 import { registerTableActionHandlers } from './azureStorageExplorer/tables/tableActionHandlers';
 import { registerTableGroupActionHandlers } from './azureStorageExplorer/tables/tableGroupActionHandlers';
 import { ext } from './extensionVariables';
@@ -65,7 +66,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<AzureE
         registerCommand('azureStorage.refresh', async (treeItem?: AzureTreeItem) => await tree.refresh(treeItem));
         registerCommand('azureStorage.copyUrl', (treeItem: AzureTreeItem & ICopyUrl) => treeItem.copyUrl());
         registerCommand('azureStorage.selectSubscriptions', () => commands.executeCommand("azure-account.selectSubscriptions"));
-        registerCommand("azureStorage.openInPortal", (treeItem: AzureTreeItem) => {
+        registerCommand("azureStorage.openInPortal", async (treeItem?: AzureTreeItem) => {
+            if (!treeItem) {
+                treeItem = <StorageAccountTreeItem>await ext.tree.showTreeItemPicker(StorageAccountTreeItem.contextValue);
+            }
+
             treeItem.openInPortal();
         });
         registerCommand("azureStorage.configureStaticWebsite", async function (this: IActionContext, treeItem?: AzureTreeItem): Promise<void> {


### PR DESCRIPTION
I thought I'd knock out some low-hanging fruit for the next release of Storage. This turned out to affect more files than I originally thought it would, but still very simple/tedious work.

1. Adds command palette support for top levels of tree. I did not add support for any commands below queue/table/file share/blob container. Fixes a lot of #221
1. Standardize use of ellipses in command name based on [these rules](https://docs.microsoft.com/en-us/windows/desktop/uxguide/cmd-menus#using-ellipses)