### PR TITLE
Fixes for CTI bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
 		"onCommand:azureStorage.downloadBlob",
 		"onCommand:azureStorage.createFileShare",
 		"onCommand:azureStorage.deleteFileShare",
-		"onCommand:azureStorage.deleteAccount",
+		"onCommand:azureStorage.deleteStorageAccount",
 		"onCommand:azureStorage.createDirectory",
 		"onCommand:azureStorage.deleteDirectory",
 		"onCommand:azureStorage.createTextFile",
@@ -216,8 +216,8 @@
 				"category": "Azure Storage"
 			},
 			{
-				"command": "azureStorage.deleteAccount",
-				"title": "Delete Account...",
+				"command": "azureStorage.deleteStorageAccount",
+				"title": "Delete Storage Account...",
 				"category": "Azure Storage"
 			},
 			{
@@ -469,7 +469,7 @@
 					"group": "7_modification"
 				},
 				{
-					"command": "azureStorage.deleteAccount",
+					"command": "azureStorage.deleteStorageAccount",
 					"when": "view == azureStorage && viewItem == azureStorageAccount",
 					"group": "7_modification"
 				},

--- a/src/azureStorageExplorer/selectStorageAccountNodeForCommand.ts
+++ b/src/azureStorageExplorer/selectStorageAccountNodeForCommand.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
-import { AzureTreeItem, IActionContext, UserCancelledError } from "vscode-azureextensionui";
+import { AzureTreeItem, IActionContext } from "vscode-azureextensionui";
 import { ext } from "../extensionVariables";
 import { BlobContainerTreeItem } from "./blobContainers/blobContainerNode";
 import { StorageAccountTreeItem } from "./storageAccounts/storageAccountNode";
@@ -62,9 +62,6 @@ export async function selectStorageAccountTreeItemForCommand(
             if (enableResponse) {
                 await accountTreeItem.configureStaticWebsite();
             }
-            // Either way can't continue
-            throw new UserCancelledError();
-
         }
     }
 

--- a/src/azureStorageExplorer/storageAccounts/storageAccountActionHandlers.ts
+++ b/src/azureStorageExplorer/storageAccounts/storageAccountActionHandlers.ts
@@ -21,7 +21,7 @@ export function registerStorageAccountActionHandlers(): void {
     registerCommand("azureStorage.copyPrimaryKey", copyPrimaryKey);
     registerCommand("azureStorage.copyConnectionString", copyConnectionString);
     registerCommand("azureStorage.deployStaticWebsite", deployStaticWebsite);
-    registerCommand("azureStorage.deleteAccount", async (treeItem?: StorageAccountTreeItem) => await deleteNode(StorageAccountTreeItem.contextValue, treeItem));
+    registerCommand("azureStorage.deleteStorageAccount", async (treeItem?: StorageAccountTreeItem) => await deleteNode(StorageAccountTreeItem.contextValue, treeItem));
 }
 
 async function openStorageAccountInStorageExplorer(treeItem?: StorageAccountTreeItem): Promise<void> {


### PR DESCRIPTION
Fixes #305, #303 

- selectStorageAccountTreeItemForCommand: Actually _return_ the treeItem once we configure the account for static websites. 
- Rename "Delete Account..." to "Delete Storage Account..." to maintain consistency with "Create Storage Account"