### PR TITLE
Add retryPolicy on creating services (blob/queue/fileshare/table)

### DIFF
--- a/src/azureStorageExplorer/storageAccounts/storageAccountNode.ts
+++ b/src/azureStorageExplorer/storageAccounts/storageAccountNode.ts
@@ -158,17 +158,17 @@ export class StorageAccountTreeItem extends AzureParentTreeItem<IStorageRoot> {
         return Object.assign({}, subRoot, {
             storageAccount: this.storageAccount,
             createBlobService: () => {
-                return azureStorage.createBlobService(this.storageAccount.name, this.key.value, this.storageAccount.primaryEndpoints.blob);
+                return azureStorage.createBlobService(this.storageAccount.name, this.key.value, this.storageAccount.primaryEndpoints.blob).withFilter(new azureStorage.ExponentialRetryPolicyFilter());
             },
             createFileService: () => {
-                return azureStorage.createFileService(this.storageAccount.name, this.key.value, this.storageAccount.primaryEndpoints.file);
+                return azureStorage.createFileService(this.storageAccount.name, this.key.value, this.storageAccount.primaryEndpoints.file).withFilter(new azureStorage.ExponentialRetryPolicyFilter());
             },
             createQueueService: () => {
-                return azureStorage.createQueueService(this.storageAccount.name, this.key.value, this.storageAccount.primaryEndpoints.queue);
+                return azureStorage.createQueueService(this.storageAccount.name, this.key.value, this.storageAccount.primaryEndpoints.queue).withFilter(new azureStorage.ExponentialRetryPolicyFilter());
             },
             createTableService: () => {
                 // tslint:disable-next-line:no-any the typings for createTableService are incorrect
-                return azureStorage.createTableService(this.storageAccount.name, this.key.value, <any>this.storageAccount.primaryEndpoints.table);
+                return azureStorage.createTableService(this.storageAccount.name, this.key.value, <any>this.storageAccount.primaryEndpoints.table).withFilter(new azureStorage.ExponentialRetryPolicyFilter());
             }
         });
     }


### PR DESCRIPTION

The timeout errors arise due to the lack of retries in blobService. 

Repro: 
```
 npx create react-app my-react-app
 cd my-react-app
 npm install
```
 Deploy the entire app, then deploy it again and choose yes to delete all files



Fixes #352 
Fixes  #345 
Fixes  #370 
Fixes #334 
Fixes #340 
Fixes #338 
Fixes #339 
Fixes #342
Fixes #317
Fixes #362 
