### PR TITLE
Differentiate between rename and move in File Share and Blob Container files

### DIFF
--- a/src/azureStorageExplorer/blobContainers/BlobContainerFS.ts
+++ b/src/azureStorageExplorer/blobContainers/BlobContainerFS.ts
@@ -12,6 +12,7 @@ import { ext } from "../../extensionVariables";
 import { findRoot } from "../findRoot";
 import { getFileSystemError } from "../getFileSystemError";
 import { IParsedUri, parseUri } from "../parseUri";
+import { showRenameError } from "../showRenameError";
 import { BlobContainerTreeItem } from './blobContainerNode';
 import { BlobDirectoryTreeItem } from "./BlobDirectoryTreeItem";
 import { BlobTreeItem } from './blobNode';
@@ -284,16 +285,7 @@ export class BlobContainerFS implements vscode.FileSystemProvider {
 
     async rename(oldUri: vscode.Uri, newUri: vscode.Uri, _options: { overwrite: boolean; }): Promise<void> {
         return await callWithTelemetryAndErrorHandling('blob.rename', async (context) => {
-            let oldUriParsed = parseUri(oldUri, this._blobContainerString);
-            let newUriParsed = parseUri(newUri, this._blobContainerString);
-
-            context.errorHandling.rethrow = true;
-            if (oldUriParsed.baseName === newUriParsed.baseName) {
-                context.errorHandling.suppressDisplay = true;
-                throw new Error('Moving folders or blobs not supported.');
-            } else {
-                throw new Error('Renaming folders or blobs not supported.');
-            }
+            showRenameError(oldUri, newUri, this._blobContainerString, context);
         });
     }
 

--- a/src/azureStorageExplorer/blobContainers/BlobContainerFS.ts
+++ b/src/azureStorageExplorer/blobContainers/BlobContainerFS.ts
@@ -287,12 +287,11 @@ export class BlobContainerFS implements vscode.FileSystemProvider {
             let oldUriParsed = parseUri(oldUri, this._blobContainerString);
             let newUriParsed = parseUri(newUri, this._blobContainerString);
 
+            context.errorHandling.rethrow = true;
             if (oldUriParsed.baseName === newUriParsed.baseName) {
-                context.errorHandling.rethrow = true;
                 context.errorHandling.suppressDisplay = true;
                 throw new Error('Moving folders or blobs not supported.');
             } else {
-                context.errorHandling.rethrow = true;
                 throw new Error('Renaming folders or blobs not supported.');
             }
         });

--- a/src/azureStorageExplorer/blobContainers/BlobContainerFS.ts
+++ b/src/azureStorageExplorer/blobContainers/BlobContainerFS.ts
@@ -282,11 +282,19 @@ export class BlobContainerFS implements vscode.FileSystemProvider {
 
     }
 
-    async rename(_oldUri: vscode.Uri, _newUri: vscode.Uri, _options: { overwrite: boolean; }): Promise<void> {
+    async rename(oldUri: vscode.Uri, newUri: vscode.Uri, _options: { overwrite: boolean; }): Promise<void> {
         return await callWithTelemetryAndErrorHandling('blob.rename', async (context) => {
-            context.errorHandling.rethrow = true;
-            context.errorHandling.suppressDisplay = true;
-            throw new Error('Renaming/moving folders or files not supported.');
+            let oldUriParsed = parseUri(oldUri, this._blobContainerString);
+            let newUriParsed = parseUri(newUri, this._blobContainerString);
+
+            if (oldUriParsed.baseName === newUriParsed.baseName) {
+                context.errorHandling.rethrow = true;
+                context.errorHandling.suppressDisplay = true;
+                throw new Error('Moving folders or blobs not supported.');
+            } else {
+                context.errorHandling.rethrow = true;
+                throw new Error('Renaming folders or blobs not supported.');
+            }
         });
     }
 

--- a/src/azureStorageExplorer/fileShares/FileShareFS.ts
+++ b/src/azureStorageExplorer/fileShares/FileShareFS.ts
@@ -200,12 +200,11 @@ export class FileShareFS implements vscode.FileSystemProvider {
             let oldUriParsed = parseUri(oldUri, this._fileShareString);
             let newUriParsed = parseUri(newUri, this._fileShareString);
 
+            context.errorHandling.rethrow = true;
             if (oldUriParsed.baseName === newUriParsed.baseName) {
-                context.errorHandling.rethrow = true;
                 context.errorHandling.suppressDisplay = true;
                 throw new Error('Moving folders or files not supported.');
             } else {
-                context.errorHandling.rethrow = true;
                 throw new Error('Renaming folders or files not supported.');
             }
         });

--- a/src/azureStorageExplorer/fileShares/FileShareFS.ts
+++ b/src/azureStorageExplorer/fileShares/FileShareFS.ts
@@ -10,6 +10,7 @@ import { callWithTelemetryAndErrorHandling, IActionContext, parseError } from "v
 import { findRoot } from "../findRoot";
 import { getFileSystemError } from "../getFileSystemError";
 import { parseUri } from "../parseUri";
+import { showRenameError } from "../showRenameError";
 import { DirectoryTreeItem } from './directoryNode';
 import { createDirectory, deleteDirectoryAndContents } from "./directoryUtils";
 import { FileTreeItem } from "./fileNode";
@@ -197,16 +198,7 @@ export class FileShareFS implements vscode.FileSystemProvider {
 
     async rename(oldUri: vscode.Uri, newUri: vscode.Uri, _options: { overwrite: boolean; }): Promise<void> {
         return await callWithTelemetryAndErrorHandling('fs.rename', async (context) => {
-            let oldUriParsed = parseUri(oldUri, this._fileShareString);
-            let newUriParsed = parseUri(newUri, this._fileShareString);
-
-            context.errorHandling.rethrow = true;
-            if (oldUriParsed.baseName === newUriParsed.baseName) {
-                context.errorHandling.suppressDisplay = true;
-                throw new Error('Moving folders or files not supported.');
-            } else {
-                throw new Error('Renaming folders or files not supported.');
-            }
+            showRenameError(oldUri, newUri, this._fileShareString, context);
         });
     }
 

--- a/src/azureStorageExplorer/fileShares/FileShareFS.ts
+++ b/src/azureStorageExplorer/fileShares/FileShareFS.ts
@@ -195,11 +195,19 @@ export class FileShareFS implements vscode.FileSystemProvider {
         });
     }
 
-    async rename(_oldUri: vscode.Uri, _newUri: vscode.Uri, _options: { overwrite: boolean; }): Promise<void> {
+    async rename(oldUri: vscode.Uri, newUri: vscode.Uri, _options: { overwrite: boolean; }): Promise<void> {
         return await callWithTelemetryAndErrorHandling('fs.rename', async (context) => {
-            context.errorHandling.rethrow = true;
-            context.errorHandling.suppressDisplay = true;
-            throw new Error('Renaming/moving folders or files not supported.');
+            let oldUriParsed = parseUri(oldUri, this._fileShareString);
+            let newUriParsed = parseUri(newUri, this._fileShareString);
+
+            if (oldUriParsed.baseName === newUriParsed.baseName) {
+                context.errorHandling.rethrow = true;
+                context.errorHandling.suppressDisplay = true;
+                throw new Error('Moving folders or files not supported.');
+            } else {
+                context.errorHandling.rethrow = true;
+                throw new Error('Renaming folders or files not supported.');
+            }
         });
     }
 

--- a/src/azureStorageExplorer/showRenameError.ts
+++ b/src/azureStorageExplorer/showRenameError.ts
@@ -1,0 +1,27 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import { AzExtTreeItem, IActionContext } from 'vscode-azureextensionui';
+import { ext } from '../extensionVariables';
+import { getFileSystemError } from './getFileSystemError';
+import { parseUri } from './parseUri';
+
+const rootMap: Map<string, AzExtTreeItem> = new Map<string, AzExtTreeItem>();
+
+export function showRenameError(oldUri: vscode.Uri, newUri: vscode.Uri, fileType: string, context: IActionContext): void {
+    let oldUriParsed = parseUri(oldUri, fileType);
+    let newUriParsed = parseUri(newUri, fileType);
+
+    context.errorHandling.rethrow = true;
+    if (oldUriParsed.baseName === newUriParsed.baseName) {
+        // Set suppressDisplay true when trying to move the files because VS code will hanlde the error.
+        context.errorHandling.suppressDisplay = true;
+        throw new Error('Moving folders or files not supported.');
+    } else {
+        // When renaming a file, VS code will not handle the error so the message must be displayed here.
+        throw new Error('Renaming folders or files not supported.');
+    }
+}

--- a/src/azureStorageExplorer/showRenameError.ts
+++ b/src/azureStorageExplorer/showRenameError.ts
@@ -4,12 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import { AzExtTreeItem, IActionContext } from 'vscode-azureextensionui';
-import { ext } from '../extensionVariables';
-import { getFileSystemError } from './getFileSystemError';
+import { IActionContext } from 'vscode-azureextensionui';
 import { parseUri } from './parseUri';
-
-const rootMap: Map<string, AzExtTreeItem> = new Map<string, AzExtTreeItem>();
 
 export function showRenameError(oldUri: vscode.Uri, newUri: vscode.Uri, fileType: string, context: IActionContext): void {
     let oldUriParsed = parseUri(oldUri, fileType);


### PR DESCRIPTION
Fixes #419 #420 

The FileShareProvider deals with errors thrown by renaming and moving file/folders differently. To accommodate this, I differentiate between rename and move by comparing the basename and throw errors differently. 

Known: If I rename a folder/file such that the folder/file would be moved to a different location, no error message is shown. For example, if there exists a folder and file b at the same location, if I rename file b to be a/b, the UI will not change and the file's location will remain the same but no error message will be shown. For now, I will leave this as is.