### PR TITLE
'View Output' button that directs to output channel when deleting blob folder

### DIFF
--- a/src/azureStorageExplorer/blobContainers/BlobContainerFS.ts
+++ b/src/azureStorageExplorer/blobContainers/BlobContainerFS.ts
@@ -230,12 +230,7 @@ export class BlobContainerFS implements vscode.FileSystemProvider {
             if (entry instanceof BlobTreeItem) {
                 await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification }, async (progress) => {
                     progress.report({ message: `Deleting blob ${parsedUri.filePath}` });
-                    try {
-                        await this.deleteBlob(parsedUri.rootName, parsedUri.filePath, blobService);
-                    } catch (error) {
-                        ext.outputChannel.appendLine(`Cannot delete ${parsedUri.baseName}. ${parseError(error).message}`);
-                        throw error;
-                    }
+                    await this.deleteBlob(parsedUri.rootName, parsedUri.filePath, blobService);
                 });
             } else if (entry instanceof BlobDirectoryTreeItem) {
                 await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification }, async (progress) => {

--- a/src/azureStorageExplorer/blobContainers/BlobContainerFS.ts
+++ b/src/azureStorageExplorer/blobContainers/BlobContainerFS.ts
@@ -241,9 +241,9 @@ export class BlobContainerFS implements vscode.FileSystemProvider {
                         // tslint:disable-next-line: no-multiline-string
                         ext.outputChannel.appendLine(`Please refresh the viewlet to see the changes made.`);
 
-                        const viewOutput: vscode.MessageItem = { title: 'View Output' };
-                        const errorMessage: string = `Errors occured when deleting ${parsedUri.filePath}. Please look at the output channel for more information.`;
-                        vscode.window.showInformationMessage(errorMessage, viewOutput).then(async (result: vscode.MessageItem | undefined) => {
+                        const viewOutput: vscode.MessageItem = { title: 'View Errors' };
+                        const errorMessage: string = `Errors occured when deleting "${parsedUri.filePath}".`;
+                        vscode.window.showWarningMessage(errorMessage, viewOutput).then(async (result: vscode.MessageItem | undefined) => {
                             if (result === viewOutput) {
                                 ext.outputChannel.show();
                             }

--- a/src/azureStorageExplorer/blobContainers/BlobContainerFS.ts
+++ b/src/azureStorageExplorer/blobContainers/BlobContainerFS.ts
@@ -246,7 +246,7 @@ export class BlobContainerFS implements vscode.FileSystemProvider {
                         // tslint:disable-next-line: no-multiline-string
                         ext.outputChannel.appendLine(`Please refresh the viewlet to see the changes made.`);
 
-                        const viewOutput: vscode.MessageItem = { title: 'View output' };
+                        const viewOutput: vscode.MessageItem = { title: 'View Output' };
                         const errorMessage: string = `Errors occured when deleting ${parsedUri.filePath}. Please look at the output channel for more information.`;
                         vscode.window.showInformationMessage(errorMessage, viewOutput).then(async (result: vscode.MessageItem | undefined) => {
                             if (result === viewOutput) {


### PR DESCRIPTION
Fixes #426 , #427 