### PR TITLE
FSExplorer: Clear cache when user explicitly refreshes explorer

### DIFF
--- a/src/azureStorageExplorer/getFileSystemError.ts
+++ b/src/azureStorageExplorer/getFileSystemError.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode';
 import { IActionContext } from "vscode-azureextensionui";
 
 export function getFileSystemError(uri: vscode.Uri | string, context: IActionContext, fsError: (messageOrUri?: string | vscode.Uri) => vscode.FileSystemError): vscode.FileSystemError {
-    context.telemetry.suppressAll = true;
+    //context.telemetry.suppressAll = true;
     context.errorHandling.rethrow = true;
     context.errorHandling.suppressDisplay = true;
     return fsError(uri);


### PR DESCRIPTION
Fixes #413

Looking at the bug and flow of code, it looks like VSCode calls stat only on refreshes, extension opens, or fileSystemProvider registration. Given the FileSystemProvider API, it looks like we would need to keep track of when to return cached results, and when we should do a re-fetch. 

For blobs, there's already a policy of explicitly refreshing at every `readDirectory` call. 
