### PR TITLE
Ignore trailing slash in parentDirPath when parsing URIs

### DIFF
--- a/src/azureStorageExplorer/blobContainers/BlobContainerFS.ts
+++ b/src/azureStorageExplorer/blobContainers/BlobContainerFS.ts
@@ -168,10 +168,6 @@ export class BlobContainerFS implements vscode.FileSystemProvider {
                     } else {
                         progress.report({ message: `Creating blob ${parsedUri.filePath}` });
                         let parent = parsedUri.parentDirPath;
-                        if (parent.endsWith('/')) {
-                            parent = parent.substring(0, parent.length - 1);
-                        }
-
                         let dir = await this.lookupAsDirectory(path.posix.join(parsedUri.rootPath, parent), context);
                         await dir.createChild(<IBlobContainerCreateChildContext>{ ...context, childType: 'azureBlob', childName: parsedUri.filePath });
                     }

--- a/src/azureStorageExplorer/parseUri.ts
+++ b/src/azureStorageExplorer/parseUri.ts
@@ -35,7 +35,7 @@ export interface IParsedUri {
 
     /**
      * Path of parent directory within container or file share
-     * e.g. parentdir1/
+     * e.g. parentdir1
      */
     parentDirPath: string;
 

--- a/src/azureStorageExplorer/parseUri.ts
+++ b/src/azureStorageExplorer/parseUri.ts
@@ -48,7 +48,7 @@ export interface IParsedUri {
 
 export function parseUri(uri: vscode.Uri | string, fileType: string): IParsedUri {
     let path: string = uri instanceof vscode.Uri ? uri.path : uri;
-    const matches: RegExpMatchArray | null = path.match(`^(\/subscriptions\/[^\/]+\/resourceGroups\/[^\/]+\/providers\/Microsoft\.Storage\/storageAccounts\/[^\/]+\/${fileType}\/([^\/]+))\/?((.*?\/?)([^\/]*))$`);
+    const matches: RegExpMatchArray | null = path.match(`^(\/subscriptions\/[^\/]+\/resourceGroups\/[^\/]+\/providers\/Microsoft\.Storage\/storageAccounts\/[^\/]+\/${fileType}\/([^\/]+))\/?((.*?)\/?([^\/]*))$`);
     if (!matches) {
         throw new Error(`Invalid ${fileType} uri. Cannot view or modify ${uri}.`);
     } else {


### PR DESCRIPTION
Fixes #455

The trailing `/` led to the parent tree item not being found in file creation due to different expectations for trailing slashes.