### PR TITLE
Make error message for duplicate tables/queues consistent

### DIFF
--- a/src/azureStorageExplorer/tables/tableGroupNode.ts
+++ b/src/azureStorageExplorer/tables/tableGroupNode.ts
@@ -78,13 +78,16 @@ export class TableGroupTreeItem extends AzureParentTreeItem<IStorageRoot> {
         throw new UserCancelledError();
     }
 
-    // tslint:disable-next-line:promise-function-async // Grandfathered in
-    private createTable(name: string): Promise<azureStorage.TableService.TableResult> {
+    private async createTable(name: string): Promise<azureStorage.TableService.TableResult> {
         return new Promise((resolve, reject) => {
             let tableService = this.root.createTableService();
-            tableService.createTable(name, (err?: Error, result?: azureStorage.TableService.TableResult) => {
+            tableService.createTable(name, (err?: Error | azureStorage.StorageError, result?: azureStorage.TableService.TableResult) => {
                 if (err) {
-                    reject(err);
+                    if ('code' in err && err.code === "TableAlreadyExists") {
+                        reject(new Error('The table specified already exists.'));
+                    } else {
+                        reject(err);
+                    }
                 } else {
                     resolve(result);
                 }

--- a/src/azureStorageExplorer/tables/tableGroupNode.ts
+++ b/src/azureStorageExplorer/tables/tableGroupNode.ts
@@ -6,7 +6,7 @@
 import * as azureStorage from "azure-storage";
 import * as path from 'path';
 import { ProgressLocation, Uri, window } from 'vscode';
-import { AzureParentTreeItem, ICreateChildImplContext, UserCancelledError } from 'vscode-azureextensionui';
+import { AzureParentTreeItem, ICreateChildImplContext, parseError, UserCancelledError } from 'vscode-azureextensionui';
 import { nonNull } from "../../components/storageWrappers";
 import { getResourcesPath } from "../../constants";
 import { IStorageRoot } from "../IStorageRoot";
@@ -81,9 +81,9 @@ export class TableGroupTreeItem extends AzureParentTreeItem<IStorageRoot> {
     private async createTable(name: string): Promise<azureStorage.TableService.TableResult> {
         return new Promise((resolve, reject) => {
             let tableService = this.root.createTableService();
-            tableService.createTable(name, (err?: Error | azureStorage.StorageError, result?: azureStorage.TableService.TableResult) => {
+            tableService.createTable(name, (err?: Error, result?: azureStorage.TableService.TableResult) => {
                 if (err) {
-                    if ('code' in err && err.code === "TableAlreadyExists") {
+                    if (parseError(err).errorType === "TableAlreadyExists") {
                         reject(new Error('The table specified already exists.'));
                     } else {
                         reject(err);


### PR DESCRIPTION
Fixes #482

### New error messages
![Screen Shot 2019-10-28 at 2 35 26 PM](https://user-images.githubusercontent.com/22795803/67720021-33223f00-f990-11e9-9691-638dc8c9c132.png)

### Old error messages
Duplicate table: 
![Screen Shot 2019-10-28 at 2 36 58 PM](https://user-images.githubusercontent.com/22795803/67720129-6bc21880-f990-11e9-9c8e-c7f113577242.png)

No error message was originally displayed for a duplicate queue.
