### PR TITLE
Don't display progress notifications when uploading blobs

### DIFF
--- a/src/editors/BlobFileHandler.ts
+++ b/src/editors/BlobFileHandler.ts
@@ -67,7 +67,7 @@ export class BlobFileHandler implements IRemoteFileHandler<BlobTreeItem> {
         await window.withProgress({ title: `Downloading ${treeItem.blob.name}`, location: ProgressLocation.Notification }, async (notificationProgress) => {
             const transferProgress: TransferProgress = new TransferProgress();
             await blockBlobClient.downloadToFile(filePath, undefined, undefined, {
-                onProgress: (transferProgressEvent) => transferProgress.report(treeItem.blob.name, transferProgressEvent.loadedBytes, totalBytes, notificationProgress)
+                onProgress: (transferProgressEvent) => transferProgress.reportToNotification(treeItem.blob.name, transferProgressEvent.loadedBytes, totalBytes, notificationProgress)
             });
         });
 

--- a/src/tree/blob/BlobContainerTreeItem.ts
+++ b/src/tree/blob/BlobContainerTreeItem.ts
@@ -434,6 +434,7 @@ export class BlobContainerTreeItem extends AzureParentTreeItem<IStorageRoot> imp
         const containerClient: azureStorageBlob.ContainerClient = createBlobContainerClient(this.root, this.container.name);
         for (let blob of blobsToDelete) {
             try {
+                ext.outputChannel.appendLine(`Deleting blob "${blob.name}"...`);
                 let response: azureStorageBlob.BlobDeleteResponse = await containerClient.deleteBlob(blob.name);
                 if (cancellationToken.isCancellationRequested) {
                     throw new UserCancelledError();


### PR DESCRIPTION
An alternative to this approach would be to suppress notifications if `suppressLogs` is true. But this implementation seemed cleaner and returns us to the old functionality before the SDK update.

Fixes #536