### PR TITLE
Load all resources in AzureStorageFS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8358,9 +8358,9 @@
 			}
 		},
 		"vscode-azureextensionui": {
-			"version": "0.28.3",
-			"resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.28.3.tgz",
-			"integrity": "sha512-VVfwRJ5/ZLSkO0Kxx6xSWnevT8F3FCimSfp8ptopdyu/nNp1iR0O9w+bPw51wXxWOFrIIcI+ExwjF/bWXHGq5w==",
+			"version": "0.29.2",
+			"resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.29.2.tgz",
+			"integrity": "sha512-3vu2PZM9GrYThTx8URc++lCt0nZCcUTfoFYm2qfuidoUEV+x+cyZ0TkTxUWun1mgEcO+fW1JuXLW9E/P7ijV7w==",
 			"requires": {
 				"azure-arm-resource": "^3.0.0-preview",
 				"azure-arm-storage": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -754,7 +754,7 @@
 		"ms-rest": "^2.2.2",
 		"ms-rest-azure": "^2.3.1",
 		"opn": "^5.3.0",
-		"vscode-azureextensionui": "^0.28.3",
+		"vscode-azureextensionui": "^0.29.1",
 		"vscode-nls": "^4.1.1",
 		"winreg": "^1.2.3"
 	}

--- a/package.json
+++ b/package.json
@@ -754,7 +754,7 @@
 		"ms-rest": "^2.2.2",
 		"ms-rest-azure": "^2.3.1",
 		"opn": "^5.3.0",
-		"vscode-azureextensionui": "^0.29.1",
+		"vscode-azureextensionui": "^0.29.2",
 		"vscode-nls": "^4.1.1",
 		"winreg": "^1.2.3"
 	}


### PR DESCRIPTION
As far as I can tell, the `FileSystemProvider` api was not designed with pagination in mind (leading to problems like https://github.com/microsoft/vscode-azurestorage/issues/436). I'm not convinced pagination is a good fit for this scenario anyways, so I don't want to push VS Code to change anything yet. As discussed offline - we will load all resources (with a "cancel" button) and revisit this based on feedback if necessary.

Depends on https://github.com/microsoft/vscode-azuretools/pull/640

Fixes https://github.com/microsoft/vscode-azurestorage/issues/398
Fixes https://github.com/microsoft/vscode-azurestorage/issues/436