### PR TITLE
Fix display of "Create Storage Account" for command palette

### DIFF
--- a/src/commands/commonTreeCommands.ts
+++ b/src/commands/commonTreeCommands.ts
@@ -8,7 +8,7 @@ import { ext } from '../extensionVariables';
 
 export async function deleteNode(context: IActionContext, expectedContextValue: string, node?: AzExtTreeItem): Promise<void> {
     if (!node) {
-        node = await ext.tree.showTreeItemPicker(expectedContextValue, context);
+        node = await ext.tree.showTreeItemPicker(expectedContextValue, { ...context, suppressCreatePick: true });
     }
 
     await node.deleteTreeItem(context);

--- a/src/tree/SubscriptionTreeItem.ts
+++ b/src/tree/SubscriptionTreeItem.ts
@@ -14,6 +14,7 @@ import { StorageAccountTreeItem } from './StorageAccountTreeItem';
 
 export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
     public childTypeLabel: string = "Storage Account";
+    public supportsAdvancedCreation: boolean = true;
 
     async loadMoreChildrenImpl(_clearCache: boolean): Promise<AzExtTreeItem[]> {
         let storageManagementClient = createAzureClient(this.root, StorageManagementClient);


### PR DESCRIPTION
First, advanced create should be an option wherever basic create is an option
Second, neither create option should be there when running a delete command

Fixes https://github.com/microsoft/vscode-azurestorage/issues/543