### PR TITLE
Improve static website configuration experience

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8317,9 +8317,9 @@
 			}
 		},
 		"vscode-azureextensionui": {
-			"version": "0.28.3",
-			"resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.28.3.tgz",
-			"integrity": "sha512-VVfwRJ5/ZLSkO0Kxx6xSWnevT8F3FCimSfp8ptopdyu/nNp1iR0O9w+bPw51wXxWOFrIIcI+ExwjF/bWXHGq5w==",
+			"version": "0.29.3",
+			"resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.29.3.tgz",
+			"integrity": "sha512-j1Sr0drH33dUATao7ArVGPBZVhamBUBgTh24CY41lWyAOyyzDtfOFqHJ74j4Zl9G3tX3hNlgYnvz5j7JWSjBLg==",
 			"requires": {
 				"azure-arm-resource": "^3.0.0-preview",
 				"azure-arm-storage": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -754,7 +754,7 @@
 		"ms-rest": "^2.2.2",
 		"ms-rest-azure": "^2.3.1",
 		"opn": "^5.3.0",
-		"vscode-azureextensionui": "^0.28.3",
+		"vscode-azureextensionui": "^0.29.3",
 		"vscode-nls": "^4.1.1",
 		"winreg": "^1.2.3"
 	}

--- a/src/commands/selectStorageAccountNodeForCommand.ts
+++ b/src/commands/selectStorageAccountNodeForCommand.ts
@@ -19,7 +19,7 @@ import { StorageAccountTreeItem } from "../tree/StorageAccountTreeItem";
 export async function selectStorageAccountTreeItemForCommand(
     treeItem: AzureTreeItem | undefined,
     context: IActionContext,
-    options: { mustBeWebsiteCapable: boolean, askToConfigureWebsite: boolean }
+    options: { mustBeWebsiteCapable: boolean, configureWebsite: boolean }
 ): Promise<StorageAccountTreeItem> {
     // treeItem should be one of:
     //   undefined
@@ -48,20 +48,9 @@ export async function selectStorageAccountTreeItemForCommand(
         let hostingStatus = await accountTreeItem.getActualWebsiteHostingStatus();
         await accountTreeItem.ensureHostingCapable(hostingStatus);
 
-        if (options.askToConfigureWebsite && !hostingStatus.enabled) {
+        if (options.configureWebsite && !hostingStatus.enabled) {
             context.telemetry.properties.cancelStep = 'StorageAccountWebSiteNotEnabled';
-            context.telemetry.properties.enableResponse = 'false';
-            let enableWebHostingPrompt = "Enable website hosting";
-            // don't check result since cancel throws UserCancelledError and only other option is 'Enable'
-            await ext.ui.showWarningMessage(
-                `Website hosting is not enabled on storage account "${accountTreeItem.label}".`,
-                { modal: true },
-                { title: enableWebHostingPrompt });
-            let enableResponse = 'true';
-            context.telemetry.properties.enableResponse = String(enableResponse);
-            if (enableResponse) {
-                await accountTreeItem.configureStaticWebsite();
-            }
+            await accountTreeItem.configureStaticWebsite();
         }
     }
 

--- a/src/commands/selectStorageAccountNodeForCommand.ts
+++ b/src/commands/selectStorageAccountNodeForCommand.ts
@@ -18,7 +18,7 @@ import { StorageAccountTreeItem } from "../tree/StorageAccountTreeItem";
  */
 export async function selectStorageAccountTreeItemForCommand(
     treeItem: AzureTreeItem | undefined,
-    context: IActionContext,
+    context: ISelectStorageAccountContext,
     options: { mustBeWebsiteCapable: boolean, configureWebsite: boolean }
 ): Promise<StorageAccountTreeItem> {
     // treeItem should be one of:
@@ -26,7 +26,7 @@ export async function selectStorageAccountTreeItemForCommand(
     //   a storage account treeItem
     //   a blob container treeItem
 
-    context.telemetry.properties.showEnableWebsiteHostingPrompt = 'true';
+    context.showEnableWebsiteHostingPrompt = true;
 
     if (!treeItem) {
         treeItem = <StorageAccountTreeItem>await ext.tree.showTreeItemPicker(StorageAccountTreeItem.contextValue, context);
@@ -53,7 +53,7 @@ export async function selectStorageAccountTreeItemForCommand(
         if (options.configureWebsite && !hostingStatus.enabled) {
             context.telemetry.properties.cancelStep = 'StorageAccountWebSiteNotEnabled';
 
-            if (context.telemetry.properties.showEnableWebsiteHostingPrompt === 'true') {
+            if (context.showEnableWebsiteHostingPrompt) {
                 context.telemetry.properties.enableResponse = 'false';
                 let enableWebHostingPrompt = "Enable website hosting";
                 // don't check result since cancel throws UserCancelledError and only other option is 'Enable'
@@ -69,4 +69,8 @@ export async function selectStorageAccountTreeItemForCommand(
     }
 
     return accountTreeItem;
+}
+
+export interface ISelectStorageAccountContext extends IActionContext {
+    showEnableWebsiteHostingPrompt?: boolean;
 }

--- a/src/commands/selectStorageAccountNodeForCommand.ts
+++ b/src/commands/selectStorageAccountNodeForCommand.ts
@@ -26,6 +26,8 @@ export async function selectStorageAccountTreeItemForCommand(
     //   a storage account treeItem
     //   a blob container treeItem
 
+    context.telemetry.properties.showEnableWebsiteHostingPrompt = 'true';
+
     if (!treeItem) {
         treeItem = <StorageAccountTreeItem>await ext.tree.showTreeItemPicker(StorageAccountTreeItem.contextValue, context);
     }
@@ -50,6 +52,18 @@ export async function selectStorageAccountTreeItemForCommand(
 
         if (options.configureWebsite && !hostingStatus.enabled) {
             context.telemetry.properties.cancelStep = 'StorageAccountWebSiteNotEnabled';
+
+            if (context.telemetry.properties.showEnableWebsiteHostingPrompt === 'true') {
+                context.telemetry.properties.enableResponse = 'false';
+                let enableWebHostingPrompt = "Enable website hosting";
+                // don't check result since cancel throws UserCancelledError and only other option is 'Enable'
+                await ext.ui.showWarningMessage(
+                    `Website hosting is not enabled on storage account "${accountTreeItem.label}".`,
+                    { modal: true },
+                    { title: enableWebHostingPrompt });
+                context.telemetry.properties.enableResponse = 'true';
+            }
+
             await accountTreeItem.configureStaticWebsite();
         }
     }

--- a/src/commands/storageAccountActionHandlers.ts
+++ b/src/commands/storageAccountActionHandlers.ts
@@ -74,7 +74,7 @@ async function deployStaticWebsite(context: IActionContext, target?: vscode.Uri 
         context,
         {
             mustBeWebsiteCapable: true,
-            askToConfigureWebsite: true
+            configureWebsite: true
         });
 
     //  Ask for source folder if needed

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -115,7 +115,7 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
                 actionContext,
                 {
                     mustBeWebsiteCapable: true,
-                    askToConfigureWebsite: false
+                    configureWebsite: false
                 });
             await accountTreeItem.configureStaticWebsite();
         });
@@ -125,7 +125,7 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
                 actionContext,
                 {
                     mustBeWebsiteCapable: false,
-                    askToConfigureWebsite: false
+                    configureWebsite: false
                 });
             await accountTreeItem.disableStaticWebsite();
         });
@@ -137,7 +137,7 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
                 actionContext,
                 {
                     mustBeWebsiteCapable: true,
-                    askToConfigureWebsite: true
+                    configureWebsite: true
                 });
             await accountTreeItem.browseStaticWebsite();
         });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -137,7 +137,7 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
                 actionContext,
                 {
                     mustBeWebsiteCapable: true,
-                    configureWebsite: true
+                    configureWebsite: false
                 });
             await accountTreeItem.browseStaticWebsite();
         });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,7 +23,7 @@ import { OpenBehaviorStep } from './commands/openInFileExplorer/OpenBehaviorStep
 import { OpenTreeItemStep } from './commands/openInFileExplorer/OpenTreeItemStep';
 import { registerQueueActionHandlers } from './commands/queue/queueActionHandlers';
 import { registerQueueGroupActionHandlers } from './commands/queue/queueGroupActionHandlers';
-import { selectStorageAccountTreeItemForCommand } from './commands/selectStorageAccountNodeForCommand';
+import { ISelectStorageAccountContext, selectStorageAccountTreeItemForCommand } from './commands/selectStorageAccountNodeForCommand';
 import { registerStorageAccountActionHandlers } from './commands/storageAccountActionHandlers';
 import { registerTableActionHandlers } from './commands/table/tableActionHandlers';
 import { registerTableGroupActionHandlers } from './commands/table/tableGroupActionHandlers';
@@ -109,7 +109,7 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
 
             await treeItem.openInPortal();
         });
-        registerCommand("azureStorage.configureStaticWebsite", async (actionContext: IActionContext, treeItem?: AzureTreeItem) => {
+        registerCommand("azureStorage.configureStaticWebsite", async (actionContext: ISelectStorageAccountContext, treeItem?: AzureTreeItem) => {
             let accountTreeItem = await selectStorageAccountTreeItemForCommand(
                 treeItem,
                 actionContext,
@@ -119,7 +119,7 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
                 });
             await accountTreeItem.configureStaticWebsite();
         });
-        registerCommand("azureStorage.disableStaticWebsite", async (actionContext: IActionContext, treeItem?: AzureTreeItem) => {
+        registerCommand("azureStorage.disableStaticWebsite", async (actionContext: ISelectStorageAccountContext, treeItem?: AzureTreeItem) => {
             let accountTreeItem = await selectStorageAccountTreeItemForCommand(
                 treeItem,
                 actionContext,
@@ -131,7 +131,7 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
         });
         registerCommand("azureStorage.createGpv2Account", createStorageAccount);
         registerCommand("azureStorage.createGpv2AccountAdvanced", createStorageAccountAdvanced);
-        registerCommand('azureStorage.browseStaticWebsite', async (actionContext: IActionContext, treeItem?: AzureTreeItem) => {
+        registerCommand('azureStorage.browseStaticWebsite', async (actionContext: ISelectStorageAccountContext, treeItem?: AzureTreeItem) => {
             let accountTreeItem = await selectStorageAccountTreeItemForCommand(
                 treeItem,
                 actionContext,

--- a/src/tree/StorageAccountTreeItem.ts
+++ b/src/tree/StorageAccountTreeItem.ts
@@ -263,7 +263,7 @@ export class StorageAccountTreeItem extends AzureParentTreeItem<IStorageRoot> {
 
     public async configureStaticWebsite(promptForSettings: boolean = true): Promise<void> {
         const defaultIndexDocument: string = 'index.html';
-        const defaultErrorDocument404Path: undefined = undefined;
+        const defaultErrorDocument404Path: string = defaultIndexDocument;
         let indexDocument: string = defaultIndexDocument;
         let errorDocument404Path: string | undefined = defaultErrorDocument404Path;
         let oldStatus: WebsiteHostingStatus = await this.getActualWebsiteHostingStatus();
@@ -279,7 +279,6 @@ export class StorageAccountTreeItem extends AzureParentTreeItem<IStorageRoot> {
             errorDocument404Path = await ext.ui.showInputBox({
                 prompt: "Enter the 404 error document path",
                 value: oldStatus.errorDocument404Path ? oldStatus.errorDocument404Path : defaultErrorDocument404Path,
-                placeHolder: 'e.g. error/documents/error.html',
                 validateInput: (value: string): string | undefined => this.validateErrorDocumentName(value)
                 // tslint:disable-next-line: strict-boolean-expressions
             }) || undefined;

--- a/src/tree/StorageAccountTreeItem.ts
+++ b/src/tree/StorageAccountTreeItem.ts
@@ -261,23 +261,30 @@ export class StorageAccountTreeItem extends AzureParentTreeItem<IStorageRoot> {
         return accountType;
     }
 
-    public async configureStaticWebsite(): Promise<void> {
-        const defaultIndexDocumentName = 'index.html';
-        let oldStatus = await this.getActualWebsiteHostingStatus();
+    public async configureStaticWebsite(promptForSettings: boolean = true): Promise<void> {
+        const defaultIndexDocument: string = 'index.html';
+        const defaultErrorDocument404Path: undefined = undefined;
+        let indexDocument: string = defaultIndexDocument;
+        let errorDocument404Path: string | undefined = defaultErrorDocument404Path;
+        let oldStatus: WebsiteHostingStatus = await this.getActualWebsiteHostingStatus();
         await this.ensureHostingCapable(oldStatus);
-        let indexDocument = await ext.ui.showInputBox({
-            prompt: "Enter the index document name",
-            value: oldStatus.indexDocument ? oldStatus.indexDocument : defaultIndexDocumentName,
-            validateInput: (value: string): string | undefined => this.validateIndexDocumentName(value)
-        });
 
-        let errorDocument404Path: string | undefined = await ext.ui.showInputBox({
-            prompt: "Enter the 404 error document path",
-            value: oldStatus.errorDocument404Path ? oldStatus.errorDocument404Path : "",
-            placeHolder: 'e.g. error/documents/error.html',
-            validateInput: (value: string): string | undefined => this.validateErrorDocumentName(value)
-            // tslint:disable-next-line: strict-boolean-expressions
-        }) || undefined;
+        if (promptForSettings) {
+            indexDocument = await ext.ui.showInputBox({
+                prompt: "Enter the index document name",
+                value: oldStatus.indexDocument ? oldStatus.indexDocument : defaultIndexDocument,
+                validateInput: (value: string): string | undefined => this.validateIndexDocumentName(value)
+            });
+
+            errorDocument404Path = await ext.ui.showInputBox({
+                prompt: "Enter the 404 error document path",
+                value: oldStatus.errorDocument404Path ? oldStatus.errorDocument404Path : defaultErrorDocument404Path,
+                placeHolder: 'e.g. error/documents/error.html',
+                validateInput: (value: string): string | undefined => this.validateErrorDocumentName(value)
+                // tslint:disable-next-line: strict-boolean-expressions
+            }) || undefined;
+        }
+
         let newStatus: azureStorageBlob.BlobServiceProperties = {
             staticWebsite: {
                 enabled: true,
@@ -289,11 +296,12 @@ export class StorageAccountTreeItem extends AzureParentTreeItem<IStorageRoot> {
         let msg = oldStatus.enabled ?
             'Static website hosting configuration updated.' :
             `The storage account '${this.label}' has been enabled for static website hosting.`;
+        // tslint:disable-next-line: strict-boolean-expressions
+        msg += ` Index document: ${indexDocument}, 404 error document: ${errorDocument404Path || 'none'}`;
         window.showInformationMessage(msg);
         if (newStatus.staticWebsite && oldStatus.enabled !== newStatus.staticWebsite.enabled) {
             await ext.tree.refresh(this);
         }
-
     }
 
     public async disableStaticWebsite(): Promise<void> {

--- a/src/tree/SubscriptionTreeItem.ts
+++ b/src/tree/SubscriptionTreeItem.ts
@@ -68,6 +68,9 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
             await accountTreeItem.configureStaticWebsite(false);
         }
 
+        // In case this account has been created via a deploy or browse command, the enable website hosting prompt shouldn't be shown
+        context.telemetry.properties.showEnableWebsiteHostingPrompt = 'false';
+
         return accountTreeItem;
     }
 

--- a/src/tree/SubscriptionTreeItem.ts
+++ b/src/tree/SubscriptionTreeItem.ts
@@ -7,6 +7,7 @@ import { StorageManagementClient } from 'azure-arm-storage';
 import { StorageAccount } from 'azure-arm-storage/lib/models';
 import * as vscode from 'vscode';
 import { AzExtTreeItem, AzureTreeItem, AzureWizard, AzureWizardExecuteStep, AzureWizardPromptStep, createAzureClient, ICreateChildImplContext, IStorageAccountWizardContext, LocationListStep, ResourceGroupCreateStep, ResourceGroupListStep, StorageAccountKind, StorageAccountPerformance, StorageAccountReplication, SubscriptionTreeItemBase } from 'vscode-azureextensionui';
+import { ISelectStorageAccountContext } from '../commands/selectStorageAccountNodeForCommand';
 import { nonNull, StorageAccountWrapper } from '../utils/storageWrappers';
 import { StorageAccountCreateStep } from './createWizard/storageAccountCreateStep';
 import { StorageAccountNameStep } from './createWizard/storageAccountNameStep';
@@ -69,7 +70,7 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
         }
 
         // In case this account has been created via a deploy or browse command, the enable website hosting prompt shouldn't be shown
-        context.telemetry.properties.showEnableWebsiteHostingPrompt = 'false';
+        (<ISelectStorageAccountContext>context).showEnableWebsiteHostingPrompt = false;
 
         return accountTreeItem;
     }

--- a/src/tree/SubscriptionTreeItem.ts
+++ b/src/tree/SubscriptionTreeItem.ts
@@ -61,7 +61,14 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
             progress.report({ message: `Creating storage account '${wizardContext.newStorageAccountName}'` });
             await wizard.execute();
         });
-        return await StorageAccountTreeItem.createStorageAccountTreeItem(this, new StorageAccountWrapper(<StorageAccount>nonNull(wizardContext.storageAccount)), storageManagementClient);
+        let accountTreeItem: StorageAccountTreeItem = await StorageAccountTreeItem.createStorageAccountTreeItem(this, new StorageAccountWrapper(<StorageAccount>nonNull(wizardContext.storageAccount)), storageManagementClient);
+
+        if (!context.advancedCreation) {
+            // Configure static website with default settings
+            await accountTreeItem.configureStaticWebsite(false);
+        }
+
+        return accountTreeItem;
     }
 
     public hasMoreChildrenImpl(): boolean {


### PR DESCRIPTION
1. No longer prompt to confirm 'enable website hosting' before configuring static website regardless of the entry point. If someone chooses to browse to or deploy their site, they likely want to enable website hosting.

2. When creating a storage account via basic create, immediately configure it for static website hosting with defaults. Default index document and error document: `index.html`

Fixes #505 
Fixes #544 