### PR TITLE
Remove `getBlob` because it doesn't work outside the first batch

### DIFF
--- a/src/tree/blob/BlobContainerTreeItem.ts
+++ b/src/tree/blob/BlobContainerTreeItem.ts
@@ -15,7 +15,7 @@ import { AzExtTreeItem, AzureParentTreeItem, AzureTreeItem, DialogResponses, Gen
 import { configurationSettingsKeys, extensionPrefix, getResourcesPath, staticWebsiteContainerName } from "../../constants";
 import { BlobFileHandler } from '../../editors/BlobFileHandler';
 import { ext } from "../../extensionVariables";
-import { createBlobContainerClient, createBlockBlobClient, createChildAsNewBlockBlob, doesBlobExist, getBlob, IBlobContainerCreateChildContext, loadMoreBlobChildren, TransferProgress } from '../../utils/blobUtils';
+import { createBlobContainerClient, createBlockBlobClient, createChildAsNewBlockBlob, doesBlobExist, IBlobContainerCreateChildContext, loadMoreBlobChildren, TransferProgress } from '../../utils/blobUtils';
 import { ICopyUrl } from '../ICopyUrl';
 import { IStorageRoot } from "../IStorageRoot";
 import { StorageAccountTreeItem } from "../StorageAccountTreeItem";
@@ -149,10 +149,9 @@ export class BlobContainerTreeItem extends AzureParentTreeItem<IStorageRoot> imp
         if (context.blobPath && context.filePath) {
             context.showCreatingTreeItem(context.blobPath);
             await this.uploadFileToBlockBlob(context.filePath, context.blobPath);
-            const actualBlob = await getBlob(this, context.blobPath);
-            return new BlobTreeItem(this, "", actualBlob, this.container);
+            return new BlobTreeItem(this, context.blobPath, this.container);
         } else if (context.childName && context.childType === BlobDirectoryTreeItem.contextValue) {
-            return new BlobDirectoryTreeItem(this, "", { name: context.childName }, this.container);
+            return new BlobDirectoryTreeItem(this, context.childName, this.container);
         } else {
             return createChildAsNewBlockBlob(this, context);
         }

--- a/src/tree/blob/BlobDirectoryTreeItem.ts
+++ b/src/tree/blob/BlobDirectoryTreeItem.ts
@@ -14,21 +14,33 @@ import { BlobContainerTreeItem, IExistingBlobContext } from "./BlobContainerTree
 import { BlobTreeItem, ISuppressMessageContext } from "./BlobTreeItem";
 
 export class BlobDirectoryTreeItem extends AzureParentTreeItem<IStorageRoot> {
-    private _continuationToken: string | undefined;
-
     public static contextValue: string = 'azureBlobDirectory';
     public contextValue: string = BlobDirectoryTreeItem.contextValue;
 
-    public fullPath: string = path.posix.join(this.parentPath, this.directory.name);
-    public dirPath: string = `${this.fullPath}${path.sep}`;
-    public label: string = this.directory.name;
+    /**
+     * The name (and only the name) of the directory
+     */
+    public readonly dirName: string;
 
-    constructor(
-        parent: BlobContainerTreeItem | BlobDirectoryTreeItem,
-        public readonly parentPath: string,
-        public readonly directory: azureStorageBlob.BlobPrefix, // directory.name should not include parent path
-        public container: azureStorageBlob.ContainerItem) {
+    /**
+     * The full path of the directory within the container. This will always end in `/`
+     */
+    public readonly dirPath: string;
+
+    private _continuationToken: string | undefined;
+
+    constructor(parent: BlobContainerTreeItem | BlobDirectoryTreeItem, dirPath: string, public container: azureStorageBlob.ContainerItem) {
         super(parent);
+        if (!dirPath.endsWith(path.posix.sep)) {
+            dirPath += path.posix.sep;
+        }
+
+        this.dirPath = dirPath;
+        this.dirName = path.basename(dirPath);
+    }
+
+    public get label(): string {
+        return this.dirName;
     }
 
     public hasMoreChildrenImpl(): boolean {
@@ -49,27 +61,27 @@ export class BlobDirectoryTreeItem extends AzureParentTreeItem<IStorageRoot> {
         if (context.childType === BlobTreeItem.contextValue) {
             return await createChildAsNewBlockBlob(this, context);
         } else {
-            return new BlobDirectoryTreeItem(this, this.dirPath, { name: context.childName }, this.container);
+            return new BlobDirectoryTreeItem(this, path.posix.join(this.dirPath, context.childName), this.container);
         }
     }
 
     public async deleteTreeItemImpl(context: IActionContext): Promise<void> {
         await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification }, async (progress) => {
-            progress.report({ message: `Deleting directory ${this.directory.name}` });
+            progress.report({ message: `Deleting directory ${this.dirName}` });
             let errors: boolean = await this.deleteFolder(context);
 
             if (errors) {
                 ext.outputChannel.appendLine('Please refresh the viewlet to see the changes made.');
 
                 const viewOutput: vscode.MessageItem = { title: 'View Errors' };
-                const errorMessage: string = `Errors occurred when deleting "${this.directory.name}".`;
+                const errorMessage: string = `Errors occurred when deleting "${this.dirName}".`;
                 vscode.window.showWarningMessage(errorMessage, viewOutput).then(async (result: vscode.MessageItem | undefined) => {
                     if (result === viewOutput) {
                         ext.outputChannel.show();
                     }
                 });
 
-                throw new Error(`Errors occurred when deleting "${this.directory.name}".`);
+                throw new Error(`Errors occurred when deleting "${this.dirName}".`);
             }
         });
     }
@@ -88,7 +100,7 @@ export class BlobDirectoryTreeItem extends AzureParentTreeItem<IStorageRoot> {
                     try {
                         await child.deleteTreeItemImpl(<ISuppressMessageContext>{ ...context, suppressMessage: true });
                     } catch (error) {
-                        ext.outputChannel.appendLine(`Cannot delete ${child.fullPath}. ${parseError(error).message}`);
+                        ext.outputChannel.appendLine(`Cannot delete ${child.blobPath}. ${parseError(error).message}`);
                         errors = true;
                     }
                 } else if (child instanceof BlobDirectoryTreeItem) {


### PR DESCRIPTION
The file system loads all blobs, but `getBlob` only ever loads the first batch. That means if you're unlucky enough to edit a file in a later batch, you'll see this error:

![Screen Shot 2020-01-08 at 9 28 27 AM](https://user-images.githubusercontent.com/11282622/72001007-558ad100-31f9-11ea-991c-7daef047c65b.png)

We don't actually need `BlobItem` on `BlobTreeItem ` or `BlobPrefix` on `BlobDirectoryTreeItem `, so I just removed `getBlob` and cleaned up the code a bit.