### PR TITLE
Create nested directories with '/' in file explorer

### DIFF
--- a/src/AzureStorageFS.ts
+++ b/src/AzureStorageFS.ts
@@ -105,7 +105,7 @@ export class AzureStorageFS implements vscode.FileSystemProvider {
 
             try {
                 let parsedUri: IParsedUri = this.parseUri(uri);
-                let response: string | undefined | null = this.isFileShareUri(uri) ? validateFileDirectoryName(parsedUri.baseName) : validateBlobDirectoryName(parsedUri.baseName);
+                let response: string | undefined = this.isFileShareUri(uri) ? validateFileDirectoryName(parsedUri.baseName) : validateBlobDirectoryName(parsedUri.baseName);
                 if (response) {
                     // Use getFileSystemError to prevent multiple error notifications
                     throw getFileSystemError(uri, context, () => { return new vscode.FileSystemError(<string>response); });

--- a/src/AzureStorageFS.ts
+++ b/src/AzureStorageFS.ts
@@ -78,7 +78,6 @@ export class AzureStorageFS implements vscode.FileSystemProvider {
         return await callWithTelemetryAndErrorHandling('readDirectory', async (context) => {
             context.telemetry.suppressIfSuccessful = true;
             let treeItem: AzureStorageDirectoryTreeItem = await this.lookupAsDirectory(uri, context);
-            await treeItem.refresh();
 
             const loadingMessage: string = localize('loadingDir', 'Loading directory "{0}"...', treeItem.label);
             let children: AzExtTreeItem[] = await treeItem.loadAllChildren({ ...context, loadingMessage });

--- a/src/utils/directoryUtils.ts
+++ b/src/utils/directoryUtils.ts
@@ -13,13 +13,13 @@ import { DirectoryTreeItem } from "../tree/fileShare/DirectoryTreeItem";
 import { IFileShareCreateChildContext } from "../tree/fileShare/FileShareTreeItem";
 import { IStorageRoot } from "../tree/IStorageRoot";
 import { createDirectoryClient, deleteFile } from "./fileUtils";
-import { validateDirectoryName } from "./validateNames";
+import { validateFileDirectoryName } from "./validateNames";
 
 // Supports both file share and directory parents
 export async function askAndCreateChildDirectory(parent: AzureParentTreeItem<IStorageRoot>, parentPath: string, shareName: string, context: ICreateChildImplContext & IFileShareCreateChildContext): Promise<DirectoryTreeItem> {
     const dirName = context.childName || await window.showInputBox({
         placeHolder: 'Enter a name for the new directory',
-        validateInput: validateDirectoryName
+        validateInput: validateFileDirectoryName
     });
 
     if (dirName) {

--- a/src/utils/validateNames.ts
+++ b/src/utils/validateNames.ts
@@ -7,7 +7,7 @@ const invalidBlobDirectoryChar = '\\'; // Prevents differing behavior when creat
 const invalidFileChars = ['"', '/', '\\', ':', '|', '<', '>', '?', '*'];
 const invalidFileCharsString = invalidFileChars.join(', ');
 
-export function validateBlobDirectoryName(name: string): string | undefined | null {
+export function validateBlobDirectoryName(name: string): string | undefined {
     if (!name || name.indexOf(invalidBlobDirectoryChar) !== -1) {
         return `Directory name cannot be empty or contain '${invalidBlobDirectoryChar}'`;
     }
@@ -15,7 +15,7 @@ export function validateBlobDirectoryName(name: string): string | undefined | nu
     return undefined;
 }
 
-export function validateFileDirectoryName(name: string): string | undefined | null {
+export function validateFileDirectoryName(name: string): string | undefined {
     const validLength = { min: 1, max: 255 };
 
     if (!name) {
@@ -33,7 +33,7 @@ export function validateFileDirectoryName(name: string): string | undefined | nu
     return undefined;
 }
 
-export function validateFileName(name: string): string | undefined | null {
+export function validateFileName(name: string): string | undefined {
     const validLength = { min: 1, max: 255 };
 
     if (!name) {

--- a/src/utils/validateNames.ts
+++ b/src/utils/validateNames.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-const invalidBlobDirectoryChar = '\\'; // Prevents differing behavior when creating blob directories via the file explorer on Mac & Windows
+const invalidBlobDirectoryChar = '\\'; // Keeps behavior consistent on Mac & Windows when creating blob directories via the file explorer
 const invalidFileChars = ['"', '/', '\\', ':', '|', '<', '>', '?', '*'];
 const invalidFileCharsString = invalidFileChars.join(', ');
 

--- a/src/utils/validateNames.ts
+++ b/src/utils/validateNames.ts
@@ -3,10 +3,19 @@
  *  Licensed under the MIT License. See License.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-const invalidChars = ['"', '/', '\\', ':', '|', '<', '>', '?', '*'];
-const invalidCharsString = invalidChars.join(', ');
+const invalidBlobDirectoryChar = '\\'; // Prevents differing behavior when creating blob directories via the file explorer on Mac & Windows
+const invalidFileChars = ['"', '/', '\\', ':', '|', '<', '>', '?', '*'];
+const invalidFileCharsString = invalidFileChars.join(', ');
 
-export function validateDirectoryName(name: string): string | undefined | null {
+export function validateBlobDirectoryName(name: string): string | undefined | null {
+    if (!name || name.indexOf(invalidBlobDirectoryChar) !== -1) {
+        return `Directory name cannot be empty or contain '${invalidBlobDirectoryChar}'`;
+    }
+
+    return undefined;
+}
+
+export function validateFileDirectoryName(name: string): string | undefined | null {
     const validLength = { min: 1, max: 255 };
 
     if (!name) {
@@ -17,8 +26,8 @@ export function validateDirectoryName(name: string): string | undefined | null {
         return `Directory name must contain between ${validLength.min} and ${validLength.max} characters`;
     }
 
-    if (invalidChars.some(ch => name.indexOf(ch) >= 0)) {
-        return `Directory name cannot contain the following characters: '${invalidCharsString}`;
+    if (invalidFileChars.some(ch => name.indexOf(ch) >= 0)) {
+        return `Directory name cannot contain the following characters: '${invalidFileCharsString}`;
     }
 
     return undefined;
@@ -35,8 +44,8 @@ export function validateFileName(name: string): string | undefined | null {
         return `Filename must contain between ${validLength.min} and ${validLength.max} characters`;
     }
 
-    if (invalidChars.some(ch => name.indexOf(ch) >= 0)) {
-        return `Filename cannot contain the following characters: ${invalidCharsString}'`;
+    if (invalidFileChars.some(ch => name.indexOf(ch) >= 0)) {
+        return `Filename cannot contain the following characters: ${invalidFileCharsString}'`;
     }
 
     return undefined;

--- a/src/utils/validateNames.ts
+++ b/src/utils/validateNames.ts
@@ -8,7 +8,7 @@ const invalidFileChars = ['"', '/', '\\', ':', '|', '<', '>', '?', '*'];
 const invalidFileCharsString = invalidFileChars.join(', ');
 
 export function validateBlobDirectoryName(name: string): string | undefined {
-    if (!name || name.indexOf(invalidBlobDirectoryChar) !== -1) {
+    if (!name || name.includes(invalidBlobDirectoryChar)) {
         return `Directory name cannot be empty or contain '${invalidBlobDirectoryChar}'`;
     }
 


### PR DESCRIPTION
This prevents nested directories for files or blobs from being created with the `\` separator. Backslashes are avoided because of [this problem](https://github.com/microsoft/vscode-azurestorage/issues/442#issuecomment-574930762) and because behavior is different between VS Code on Windows & Mac for `\` separators.

Fixes https://github.com/microsoft/vscode-azurestorage/issues/442