### PR TITLE
Add better error message when saving a file

### DIFF
--- a/src/editors/RemoteFileEditor.ts
+++ b/src/editors/RemoteFileEditor.ts
@@ -7,7 +7,7 @@ import * as fse from 'fs-extra';
 import * as path from "path";
 import * as vscode from "vscode";
 import { TextDocument, window } from 'vscode';
-import { DialogResponses, IActionContext, UserCancelledError } from 'vscode-azureextensionui';
+import { DialogResponses, IActionContext, parseError, UserCancelledError } from 'vscode-azureextensionui';
 import { ext } from '../extensionVariables';
 import { TemporaryFile } from '../utils/temporaryFile';
 import { IRemoteFileHandler } from './IRemoteFileHandler';
@@ -83,8 +83,7 @@ export class RemoteFileEditor<ContextT> implements vscode.Disposable {
             await this.remoteFileHandler.uploadFile(context, document.fileName);
             this.appendLineToOutput(`Successfully updated '${fileName}'`);
         } catch (error) {
-            this.appendLineToOutput(`Unable to save '${fileName}'`);
-            this.appendLineToOutput(`Error Details: ${error}`);
+            this.appendLineToOutput(`Unable to save '${fileName}': ${parseError(error).message}`);
         }
     }
 


### PR DESCRIPTION
Old error:

![](https://user-images.githubusercontent.com/34729092/72781859-483ffe80-3c5d-11ea-95ea-4c8296842118.png)

New error:

![Screen Shot 2020-01-21 at 10 26 34 AM](https://user-images.githubusercontent.com/22795803/72831922-a8707980-3c38-11ea-8320-f31e0f7dd239.png)

Fixes #583