### PR TITLE
Make TransferProgress more portable

### DIFF
--- a/src/editors/BlobFileHandler.ts
+++ b/src/editors/BlobFileHandler.ts
@@ -68,9 +68,9 @@ export class BlobFileHandler implements IRemoteFileHandler<BlobTreeItem> {
         ext.outputChannel.appendLine(`Downloading ${treeItem.blobName} to ${filePath}...`);
 
         await window.withProgress({ title: `Downloading ${treeItem.blobName}`, location: ProgressLocation.Notification }, async (notificationProgress) => {
-            const transferProgress: TransferProgress = new TransferProgress();
+            const transferProgress: TransferProgress = new TransferProgress(totalBytes, treeItem.blobName);
             await blockBlobClient.downloadToFile(filePath, undefined, undefined, {
-                onProgress: (transferProgressEvent) => transferProgress.reportToNotification(treeItem.blobName, transferProgressEvent.loadedBytes, totalBytes, notificationProgress)
+                onProgress: (transferProgressEvent) => transferProgress.reportToNotification(transferProgressEvent.loadedBytes, notificationProgress)
             });
         });
 

--- a/src/tree/blob/BlobContainerTreeItem.ts
+++ b/src/tree/blob/BlobContainerTreeItem.ts
@@ -468,13 +468,13 @@ export class BlobContainerTreeItem extends AzureParentTreeItem<IStorageRoot> imp
             ext.outputChannel.appendLine(`Uploading ${filePath} as ${blobFriendlyPath}`);
         }
 
-        const transferProgress: TransferProgress = new TransferProgress();
+        const transferProgress: TransferProgress = new TransferProgress(totalBytes, blobPath);
         const options: azureStorageBlob.BlockBlobParallelUploadOptions = {
             blobHTTPHeaders: {
                 // tslint:disable-next-line: strict-boolean-expressions
                 blobContentType: mime.getType(blobPath) || undefined
             },
-            onProgress: suppressLogs ? undefined : (transferProgressEvent: TransferProgressEvent) => transferProgress.reportToOutputWindow(blobPath, transferProgressEvent.loadedBytes, totalBytes)
+            onProgress: suppressLogs ? undefined : (transferProgressEvent: TransferProgressEvent) => transferProgress.reportToOutputWindow(transferProgressEvent.loadedBytes)
         };
         await blockBlobClient.uploadFile(filePath, options);
 

--- a/src/utils/blobUtils.ts
+++ b/src/utils/blobUtils.ts
@@ -156,11 +156,7 @@ export class TransferProgress {
 
     private preReport(finishedWork: number): void {
         this.percentage = Math.trunc((finishedWork / this.totalWork) * 100);
-
-        let prefix: string = '';
-        if (this.messagePrefix) {
-            prefix = `${this.messagePrefix}: `;
-        }
+        const prefix: string = this.messagePrefix ? `${this.messagePrefix}: ` : '';
         this.message = `${prefix}${finishedWork}/${this.totalWork} (${this.percentage}%)`;
     }
 


### PR DESCRIPTION
This lets us use `TransferProgress` for more than just single blob transfers

Related to #159