### PR TITLE
Refactor 'Upload Block Blob...' command

### DIFF
--- a/package.json
+++ b/package.json
@@ -210,7 +210,7 @@
             },
             {
                 "command": "azureStorage.uploadBlockBlob",
-                "title": "Upload Block Blob...",
+                "title": "Upload File...",
                 "category": "Azure Storage"
             },
             {

--- a/src/tree/blob/BlobContainerTreeItem.ts
+++ b/src/tree/blob/BlobContainerTreeItem.ts
@@ -181,16 +181,6 @@ export class BlobContainerTreeItem extends AzureParentTreeItem<IStorageRoot> imp
                 canSelectMany: false,
                 defaultUri: lastUploadFolder,
                 filters: {
-                    "Text files": [
-                        'csv',
-                        'json',
-                        'log',
-                        'md',
-                        'rtf',
-                        'txt',
-                        'text',
-                        'xml',
-                    ],
                     "All files": ['*']
                 },
                 openLabel: "Upload"
@@ -204,7 +194,7 @@ export class BlobContainerTreeItem extends AzureParentTreeItem<IStorageRoot> imp
             await this.checkCanUpload(context, filePath);
 
             let blobPath = await vscode.window.showInputBox({
-                prompt: 'Enter a name for the uploaded block blob (may include a path)',
+                prompt: 'Enter a name for the uploaded file (may include a path)',
                 value: path.basename(filePath),
                 validateInput: BlobContainerTreeItem.validateBlobName
             });


### PR DESCRIPTION
This changes the external facing 'block blob' verbiage to 'file'. I also removed the text file filter when selecting files to upload since it sounds like it was not helpful.

Fixes https://github.com/microsoft/vscode-azurestorage/issues/687