### PR TITLE
Remove 4MB upload/download limit for blobs

### DIFF
--- a/src/tree/blob/BlobContainerTreeItem.ts
+++ b/src/tree/blob/BlobContainerTreeItem.ts
@@ -18,7 +18,6 @@ import { TransferProgress } from '../../TransferProgress';
 import { createBlobContainerClient, createBlockBlobClient, createChildAsNewBlockBlob, doesBlobExist, IBlobContainerCreateChildContext, loadMoreBlobChildren } from '../../utils/blobUtils';
 import { throwIfCanceled } from '../../utils/errorUtils';
 import { listFilePathsWithAzureSeparator } from '../../utils/fs';
-import { Limits } from '../../utils/limits';
 import { uploadFiles } from '../../utils/uploadUtils';
 import { ICopyUrl } from '../ICopyUrl';
 import { IStorageRoot } from "../IStorageRoot";
@@ -200,8 +199,6 @@ export class BlobContainerTreeItem extends AzureParentTreeItem<IStorageRoot> imp
             let uri = uris[0];
             lastUploadFolder = uri;
             let filePath = uri.fsPath;
-
-            await this.checkCanUpload(context, filePath);
 
             let blobPath = await vscode.window.showInputBox({
                 prompt: 'Enter a name for the uploaded block blob (may include a path)',
@@ -417,20 +414,5 @@ export class BlobContainerTreeItem extends AzureParentTreeItem<IStorageRoot> imp
         }
 
         return undefined;
-    }
-
-    private async checkCanUpload(context: IActionContext, localPath: string): Promise<void> {
-        let size = (await fse.stat(localPath)).size;
-        context.telemetry.measurements.blockBlobUploadSize = size;
-        if (size > Limits.maxUploadDownloadSizeBytes) {
-            context.telemetry.properties.blockBlobTooLargeForUpload = 'true';
-            await Limits.askOpenInStorageExplorer(
-                context,
-                `Please use Storage Explorer to upload files larger than ${Limits.maxUploadDownloadSizeMB}MB.`,
-                this.root.storageAccountId,
-                this.root.subscriptionId,
-                'Azure.BlobContainer',
-                this.container.name);
-        }
     }
 }

--- a/src/tree/blob/BlobTreeItem.ts
+++ b/src/tree/blob/BlobTreeItem.ts
@@ -14,7 +14,7 @@ import { getResourcesPath } from "../../constants";
 import { ext } from "../../extensionVariables";
 import { TransferProgress } from "../../TransferProgress";
 import { createBlobClient, createBlockBlobClient } from '../../utils/blobUtils';
-import { Limits } from "../../utils/limits";
+import { askOpenInStorageExplorer } from "../../utils/limits";
 import { ICopyUrl } from '../ICopyUrl';
 import { IStorageRoot } from "../IStorageRoot";
 
@@ -118,16 +118,10 @@ export class BlobTreeItem extends AzureTreeItem<IStorageRoot> implements ICopyUr
         let props: BlobGetPropertiesResponse = await client.getProperties();
 
         context.telemetry.measurements.blobDownloadSize = props.contentLength;
-        if (Number(props.contentLength) > Limits.maxUploadDownloadSizeBytes) {
-            context.telemetry.properties.blobTooLargeForDownload = 'true';
-            message = `Please use Storage Explorer for blobs larger than ${Limits.maxUploadDownloadSizeMB}MB.`;
-        } else if (props.blobType && !props.blobType.toLocaleLowerCase().startsWith("block")) {
+        if (props.blobType && !props.blobType.toLocaleLowerCase().startsWith("block")) {
             context.telemetry.properties.invalidBlobTypeForDownload = 'true';
             message = `Please use Storage Explorer for blobs of type '${props.blobType}'.`;
-        }
-
-        if (message) {
-            await Limits.askOpenInStorageExplorer(context, message, this.root.storageAccountId, this.root.subscriptionId, 'Azure.BlobContainer', this.container.name);
+            await askOpenInStorageExplorer(context, message, this.root.storageAccountId, this.root.subscriptionId, 'Azure.BlobContainer', this.container.name);
         }
     }
 }

--- a/src/utils/limits.ts
+++ b/src/utils/limits.ts
@@ -8,21 +8,15 @@ import { IActionContext, UserCancelledError } from "vscode-azureextensionui";
 import { ResourceType } from "../storageExplorerLauncher/ResourceType";
 import { storageExplorerLauncher } from "../storageExplorerLauncher/storageExplorerLauncher";
 
-export namespace Limits {
-    //  VS Code currently supports at least 256MB, but not 512MB. But it won't open anything larger than 4MB through the APIs.
-    export const maxUploadDownloadSizeMB = 4;
-    export const maxUploadDownloadSizeBytes = maxUploadDownloadSizeMB * 1000 * 1000;
+export async function askOpenInStorageExplorer(context: IActionContext, errorMessage: string, resourceId: string, subscriptionId: string, resourceType: ResourceType, resourceName: string): Promise<void> {
+    const message = "Open container in Storage Explorer";
+    window.showErrorMessage(errorMessage, message).then(async result => {
+        if (result === message) {
+            context.telemetry.properties.openInStorageExplorer = 'true';
+            await storageExplorerLauncher.openResource(resourceId, subscriptionId, resourceType, resourceName);
+        }
+    });
 
-    export async function askOpenInStorageExplorer(context: IActionContext, errorMessage: string, resourceId: string, subscriptionId: string, resourceType: ResourceType, resourceName: string): Promise<void> {
-        const message = "Open container in Storage Explorer";
-        window.showErrorMessage(errorMessage, message).then(async result => {
-            if (result === message) {
-                context.telemetry.properties.openInStorageExplorer = 'true';
-                await storageExplorerLauncher.openResource(resourceId, subscriptionId, resourceType, resourceName);
-            }
-        });
-
-        // Either way, throw canceled error
-        throw new UserCancelledError(message);
-    }
+    // Either way, throw canceled error
+    throw new UserCancelledError(message);
 }


### PR DESCRIPTION
After removing the limit, I uploaded a 490MB file and it worked fine (it just took a long time of course). I assume its still worth switching over to azcopy for this functionality though.

Related to https://github.com/microsoft/vscode-azurestorage/issues/686