### PR TITLE
Make 'Deploy to Static Website...' command title less ambiguous

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
             },
             {
                 "command": "azureStorage.deployStaticWebsite",
-                "title": "Deploy to Static Website...",
+                "title": "Deploy to Static Website via Azure Storage...",
                 "category": "Azure Storage",
                 "icon": {
                     "light": "resources/light/Deploy.svg",


### PR DESCRIPTION
Here's the new title: 

<img width="353" alt="Screen Shot 2020-07-15 at 3 43 06 PM" src="https://user-images.githubusercontent.com/22795803/87607510-5a51a580-c6b2-11ea-8487-9e6879eda2f5.png">

This title is kinda long... But it's descriptive. Open to more opinions on this one. 

Fixes https://github.com/microsoft/vscode-azurestorage/issues/695