### PR TITLE
Always open in new window for emulated storage accounts

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -80,6 +80,9 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
             }
 
             const wizardContext: IOpenInFileExplorerWizardContext = Object.assign(actionContext, { treeItem });
+            if (treeItem.root.isEmulated) {
+                wizardContext.openBehavior = 'OpenInNewWindow';
+            }
             const wizard: AzureWizard<IOpenInFileExplorerWizardContext> = new AzureWizard(wizardContext, {
                 promptSteps: [new OpenBehaviorStep()],
                 executeSteps: [new OpenTreeItemStep()]


### PR DESCRIPTION
For "Open in File Explorer...": Opening in current window or adding to workspace produced the same error, so always open in a new window.

Fixes https://github.com/microsoft/vscode-azurestorage/issues/646