### PR TITLE
Remove references to old file share SDK

### DIFF
--- a/package.json
+++ b/package.json
@@ -804,8 +804,8 @@
         "webpack-cli": "^3.1.2"
     },
     "dependencies": {
-        "@azure/storage-blob": "^12.0.0",
-        "@azure/storage-file-share": "^12.0.0",
+        "@azure/storage-blob": "^12.1.1",
+        "@azure/storage-file-share": "^12.1.1",
         "@types/mime": "^2.0.1",
         "azure-arm-resource": "^3.1.1-preview",
         "azure-arm-storage": "^5.1.1-preview",

--- a/src/tree/AttachedStorageAccountTreeItem.ts
+++ b/src/tree/AttachedStorageAccountTreeItem.ts
@@ -121,10 +121,6 @@ class AttachedStorageRoot extends AttachedAccountRoot {
         return azureStorageBlob.BlobServiceClient.fromConnectionString(this._connectionString, this._serviceClientPipelineOptions);
     }
 
-    public createFileService(): azureStorage.FileService {
-        return new azureStorage.FileService(this._connectionString);
-    }
-
     public createShareServiceClient(): azureStorageShare.ShareServiceClient {
         return azureStorageShare.ShareServiceClient.fromConnectionString(this._connectionString, this._serviceClientPipelineOptions);
     }

--- a/src/tree/IStorageRoot.ts
+++ b/src/tree/IStorageRoot.ts
@@ -15,7 +15,6 @@ export interface IStorageRoot extends ISubscriptionContext {
     isEmulated: boolean;
     primaryEndpoints?: Endpoints;
     createBlobServiceClient(): azureStorageBlob.BlobServiceClient;
-    createFileService(): azureStorage.FileService;
     createShareServiceClient(): azureStorageShare.ShareServiceClient;
     createQueueService(): azureStorage.QueueService;
     createTableService(): azureStorage.TableService;

--- a/src/tree/StorageAccountTreeItem.ts
+++ b/src/tree/StorageAccountTreeItem.ts
@@ -155,9 +155,6 @@ export class StorageAccountTreeItem extends AzureParentTreeItem<IStorageRoot> {
                 const credential = new azureStorageBlob.StorageSharedKeyCredential(this.storageAccount.name, this.key.value);
                 return new azureStorageBlob.BlobServiceClient(nonNullProp(this.storageAccount.primaryEndpoints, 'blob'), credential);
             },
-            createFileService: () => {
-                return azureStorage.createFileService(this.storageAccount.name, this.key.value, this.storageAccount.primaryEndpoints.file).withFilter(new azureStorage.ExponentialRetryPolicyFilter());
-            },
             createShareServiceClient: () => {
                 const credential = new azureStorageShare.StorageSharedKeyCredential(this.storageAccount.name, this.key.value);
                 return new azureStorageShare.ShareServiceClient(nonNullProp(this.storageAccount.primaryEndpoints, 'file'), credential);

--- a/src/tree/fileShare/FileShareTreeItem.ts
+++ b/src/tree/fileShare/FileShareTreeItem.ts
@@ -146,14 +146,7 @@ export class FileShareTreeItem extends AzureParentTreeItem<IStorageRoot> impleme
             },
             onProgress: suppressLogs ? undefined : (transferProgressEvent: TransferProgressEvent) => transferProgress.reportToOutputWindow(transferProgressEvent.loadedBytes)
         };
-
-        if (fileSize) {
-            await fileClient.uploadFile(sourceFilePath, options);
-        } else {
-            // uploadFile hangs indefinately if the source file size is zero, so create an empty file
-            // Related: https://github.com/Azure/azure-sdk-for-js/issues/6904
-            await fileClient.create(0, options);
-        }
+        await fileClient.uploadFile(sourceFilePath, options);
 
         if (!suppressLogs) {
             ext.outputChannel.appendLog(`Successfully uploaded ${destDisplayPath}.`);


### PR DESCRIPTION
When onboarding the new SDK, file uploads for empty files would hang indefinitely so we reverted to the old SDK for those few special cases. [That issue](https://github.com/Azure/azure-sdk-for-js/issues/6904) was fixed in v12.1.1 of the new SDKs. I only ran into the problem for file shares but it looks like they shipped a [similar fix](https://github.com/XiaoningLiu/azure-sdk-for-js/commit/269aeeb117334a173b505bda2f28a4abd76bf3a9#diff-1ac4ced9d9574e91d2b0b5da1658680dR6) for blobs, so I bumped both SDK versions here.