### PR TITLE
Update file name & blob path prompts

### DIFF
--- a/src/commands/blob/blobContainerActionHandlers.ts
+++ b/src/commands/blob/blobContainerActionHandlers.ts
@@ -12,7 +12,7 @@ import { storageExplorerLauncher } from '../../storageExplorerLauncher/storageEx
 import { BlobContainerTreeItem } from '../../tree/blob/BlobContainerTreeItem';
 import { BlobDirectoryTreeItem } from '../../tree/blob/BlobDirectoryTreeItem';
 import { BlobTreeItem } from '../../tree/blob/BlobTreeItem';
-import { IBlobContainerCreateChildContext, showBlobPathInputBox } from '../../utils/blobUtils';
+import { getBlobPath, IBlobContainerCreateChildContext } from '../../utils/blobUtils';
 import { localize } from '../../utils/localize';
 import { deleteNode } from '../commonTreeCommands';
 
@@ -21,7 +21,7 @@ export function registerBlobContainerActionHandlers(): void {
     registerCommand("azureStorage.editBlob", async (_context: IActionContext, treeItem: BlobTreeItem) => AzureStorageFS.showEditor(treeItem), 250);
     registerCommand("azureStorage.deleteBlobContainer", async (context: IActionContext, treeItem?: BlobContainerTreeItem) => await deleteNode(context, BlobContainerTreeItem.contextValue, treeItem));
     registerCommand("azureStorage.createBlockBlob", async (context: IActionContext, parent: BlobContainerTreeItem) => {
-        const blobPath: string = await showBlobPathInputBox(parent);
+        const blobPath: string = await getBlobPath(parent);
         const dirNames: string[] = blobPath.includes('/') ? path.dirname(blobPath).split('/') : [];
         let dirParentTreeItem: BlobDirectoryTreeItem | BlobContainerTreeItem = parent;
 

--- a/src/utils/blobUtils.ts
+++ b/src/utils/blobUtils.ts
@@ -57,7 +57,7 @@ export async function loadMoreBlobChildren(parent: BlobContainerTreeItem | BlobD
 
 // Currently only supports creating block blobs
 export async function createChildAsNewBlockBlob(parent: BlobContainerTreeItem | BlobDirectoryTreeItem, context: ICreateChildImplContext & IBlobContainerCreateChildContext): Promise<BlobTreeItem> {
-    let blobPath: string = context.childName || await showBlobPathInputBox(parent);
+    let blobPath: string = context.childName || await getBlobPath(parent);
 
     return await vscode.window.withProgress({ location: vscode.ProgressLocation.Window }, async (progress) => {
         context.showCreatingTreeItem(blobPath);
@@ -107,8 +107,9 @@ export async function getExistingProperties(parent: BlobTreeItem | BlobContainer
     return undefined;
 }
 
-export async function showBlobPathInputBox(parent: BlobContainerTreeItem | BlobDirectoryTreeItem): Promise<string> {
+export async function getBlobPath(parent: BlobContainerTreeItem | BlobDirectoryTreeItem, value?: string): Promise<string> {
     return await ext.ui.showInputBox({
+        value,
         placeHolder: localize('enterNameForNewBlockBlob', 'Enter a name for the new block blob'),
         validateInput: async (name: string) => {
             let nameError = BlobContainerTreeItem.validateBlobName(name);


### PR DESCRIPTION
I plan on using these prompts in `uploadToAzureStorage` for single file uploads. `value` was added as a parameter so that the existing file name can be pre-filled.

I was running into problems where an invalid name (in the case of file shares) was causing the upload to fail. This prevents invalid names from being accepted.