### PR TITLE
Remove unneeded error handling & fix failed/skipped transfers listing

### DIFF
--- a/src/commands/azCopy/azCopyTransfer.ts
+++ b/src/commands/azCopy/azCopyTransfer.ts
@@ -47,6 +47,9 @@ export async function azCopyTransfer(
                     ext.outputChannel.appendLog(`\t${skippedTransfer.Dst}`);
                 }
             }
+        } else {
+            // Add an additional error log since we don't have any more info about the failure
+            ext.outputChannel.appendLog(localize('couldNotUpload', 'Could not upload "{0}"', src.path));
         }
         message += finalTransferStatus?.ErrorMsg ? ` ${finalTransferStatus.ErrorMsg}` : '';
 

--- a/src/commands/azCopy/azCopyTransfer.ts
+++ b/src/commands/azCopy/azCopyTransfer.ts
@@ -24,7 +24,6 @@ export async function azCopyTransfer(
     }>,
     cancellationToken?: CancellationToken
 ): Promise<void> {
-    context.errorHandling.rethrow = true;
     const copyClient: AzCopyClient = new AzCopyClient();
     const copyOptions: ICopyOptions = { fromTo, overwriteExisting: "true", recursive: true, followSymLinks: true, excludePath: '.git;.vscode' };
     let jobId: string = await startAndWaitForCopy(context, copyClient, src, dst, copyOptions, transferProgress, notificationProgress, cancellationToken);
@@ -33,16 +32,16 @@ export async function azCopyTransfer(
     if (!finalTransferStatus || finalTransferStatus.JobStatus !== 'Completed') {
         // tslint:disable-next-line: strict-boolean-expressions
         let message: string = localize('azCopyTransfer', 'AzCopy Transfer: "{0}".', finalTransferStatus?.JobStatus || 'Failed');
-        if (finalTransferStatus?.FailedTransfers || finalTransferStatus?.SkippedTransfers) {
+        if (finalTransferStatus?.FailedTransfers?.length || finalTransferStatus?.SkippedTransfers?.length) {
             message += localize('checkOutputWindow', ' Check the output window for a list of incomplete transfers.');
 
-            if (finalTransferStatus.FailedTransfers) {
+            if (finalTransferStatus.FailedTransfers?.length) {
                 ext.outputChannel.appendLog(localize('failedTransfers', 'Failed transfers:'));
                 for (let failedTransfer of finalTransferStatus.FailedTransfers) {
                     ext.outputChannel.appendLog(`\t${failedTransfer.Dst}`);
                 }
             }
-            if (finalTransferStatus.SkippedTransfers) {
+            if (finalTransferStatus.SkippedTransfers?.length) {
                 ext.outputChannel.appendLog(localize('skippedTransfers', 'Skipped transfers:'));
                 for (let skippedTransfer of finalTransferStatus.SkippedTransfers) {
                     ext.outputChannel.appendLog(`\t${skippedTransfer.Dst}`);

--- a/src/commands/azCopy/azCopyTransfer.ts
+++ b/src/commands/azCopy/azCopyTransfer.ts
@@ -30,6 +30,8 @@ export async function azCopyTransfer(
     let finalTransferStatus = (await copyClient.getJobInfo(jobId)).latestStatus;
     context.telemetry.properties.jobStatus = finalTransferStatus?.JobStatus;
     if (!finalTransferStatus || finalTransferStatus.JobStatus !== 'Completed') {
+        ext.outputChannel.appendLog(localize('couldNotUpload', 'Could not upload "{0}"', src.path));
+
         // tslint:disable-next-line: strict-boolean-expressions
         let message: string = localize('azCopyTransfer', 'AzCopy Transfer: "{0}".', finalTransferStatus?.JobStatus || 'Failed');
         if (finalTransferStatus?.FailedTransfers?.length || finalTransferStatus?.SkippedTransfers?.length) {

--- a/src/commands/azCopy/azCopyTransfer.ts
+++ b/src/commands/azCopy/azCopyTransfer.ts
@@ -30,8 +30,6 @@ export async function azCopyTransfer(
     let finalTransferStatus = (await copyClient.getJobInfo(jobId)).latestStatus;
     context.telemetry.properties.jobStatus = finalTransferStatus?.JobStatus;
     if (!finalTransferStatus || finalTransferStatus.JobStatus !== 'Completed') {
-        ext.outputChannel.appendLog(localize('couldNotUpload', 'Could not upload "{0}"', src.path));
-
         // tslint:disable-next-line: strict-boolean-expressions
         let message: string = localize('azCopyTransfer', 'AzCopy Transfer: "{0}".', finalTransferStatus?.JobStatus || 'Failed');
         if (finalTransferStatus?.FailedTransfers?.length || finalTransferStatus?.SkippedTransfers?.length) {

--- a/src/tree/blob/BlobContainerTreeItem.ts
+++ b/src/tree/blob/BlobContainerTreeItem.ts
@@ -19,7 +19,6 @@ import { ext } from "../../extensionVariables";
 import { TransferProgress } from '../../TransferProgress';
 import { createBlobContainerClient, createChildAsNewBlockBlob, doesBlobExist, getBlobPath, IBlobContainerCreateChildContext, loadMoreBlobChildren } from '../../utils/blobUtils';
 import { throwIfCanceled } from '../../utils/errorUtils';
-import { localize } from '../../utils/localize';
 import { uploadFiles, warnFileAlreadyExists } from '../../utils/uploadUtils';
 import { ICopyUrl } from '../ICopyUrl';
 import { IStorageRoot } from "../IStorageRoot";
@@ -320,12 +319,7 @@ export class BlobContainerTreeItem extends AzureParentTreeItem<IStorageRoot> imp
         // tslint:disable-next-line: strict-boolean-expressions
         const totalBytes: number = (await fse.stat(filePath)).size || 1;
         const transferProgress: TransferProgress = new TransferProgress(totalBytes, blobPath);
-        try {
-            await azCopyTransfer(context, 'LocalBlob', src, dst, transferProgress);
-        } catch {
-            ext.outputChannel.appendLog(localize('couldNotUpload', 'Could not upload file "{0}"', filePath));
-            return;
-        }
+        await azCopyTransfer(context, 'LocalBlob', src, dst, transferProgress);
 
         if (!suppressLogs) {
             ext.outputChannel.appendLog(`Successfully uploaded ${blobFriendlyPath}.`);


### PR DESCRIPTION
We no longer need additional error handling when calling `azCopyTransfer`.

Also, `finalTransferStatus?.FailedTransfers` tends to be `[]` instead of null so not explicitly checking the length led to failed transfers being output when there were none.

Here's an example of errors for the same failed file transfer:

| Old  | New  |
|---|---|
| <img width="605" alt="Screen Shot 2020-09-02 at 2 08 14 PM" src="https://user-images.githubusercontent.com/22795803/92037287-66f39100-ed26-11ea-8c96-7f448ed6bc97.png">  | <img width="605" alt="Screen Shot 2020-09-02 at 2 07 11 PM" src="https://user-images.githubusercontent.com/22795803/92037278-62c77380-ed26-11ea-9a59-c159669c8723.png">  |





