### PR TITLE
Split 'uploadToAzureStorage' into 'uploadFiles' and 'uploadFolder'

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
         "onCommand:azureStorage.createBlobContainer",
         "onCommand:azureStorage.deleteBlobContainer",
         "onCommand:azureStorage.createBlockBlob",
-        "onCommand:azureStorage.uploadFolder",
         "onCommand:azureStorage.uploadFiles",
+        "onCommand:azureStorage.uploadFolder",
         "onCommand:azureStorage.deleteBlob",
         "onCommand:azureStorage.downloadBlob",
         "onCommand:azureStorage.createFileShare",
@@ -210,13 +210,13 @@
                 "category": "Azure Storage"
             },
             {
-                "command": "azureStorage.uploadFolder",
-                "title": "Upload Folder...",
+                "command": "azureStorage.uploadFiles",
+                "title": "Upload Files...",
                 "category": "Azure Storage"
             },
             {
-                "command": "azureStorage.uploadFiles",
-                "title": "Upload Files...",
+                "command": "azureStorage.uploadFolder",
+                "title": "Upload Folder...",
                 "category": "Azure Storage"
             },
             {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
         "onCommand:azureStorage.createBlobContainer",
         "onCommand:azureStorage.deleteBlobContainer",
         "onCommand:azureStorage.createBlockBlob",
-        "onCommand:azureStorage.uploadFile",
+        "onCommand:azureStorage.uploadFiles",
         "onCommand:azureStorage.deleteBlob",
         "onCommand:azureStorage.downloadBlob",
         "onCommand:azureStorage.createFileShare",
@@ -69,7 +69,7 @@
         "onCommand:azureStorage.deleteTable",
         "onCommand:azureStorage.createQueue",
         "onCommand:azureStorage.deleteQueue",
-        "onCommand:azureStorage.uploadToAzureStorage",
+        "onCommand:azureStorage.uploadFolder",
         "onCommand:azureStorage.attachStorageAccount",
         "onCommand:azureStorage.detachStorageAccount",
         "onCommand:azureStorage.startBlobEmulator",
@@ -209,8 +209,8 @@
                 "category": "Azure Storage"
             },
             {
-                "command": "azureStorage.uploadFile",
-                "title": "Upload File...",
+                "command": "azureStorage.uploadFiles",
+                "title": "Upload Files...",
                 "category": "Azure Storage"
             },
             {
@@ -298,8 +298,8 @@
                 "category": "Azure Storage"
             },
             {
-                "command": "azureStorage.uploadToAzureStorage",
-                "title": "Upload to Azure Storage...",
+                "command": "azureStorage.uploadFolder",
+                "title": "Upload Folder...",
                 "category": "Azure Storage"
             },
             {
@@ -357,8 +357,13 @@
                     "group": "zzz_azuretools_deploy@3"
                 },
                 {
-                    "command": "azureStorage.uploadToAzureStorage",
-                    "when": "isFileSystemResource == true",
+                    "command": "azureStorage.uploadFiles",
+                    "when": "isFileSystemResource == true && explorerResourceIsFolder == false",
+                    "group": "zzzz_azurestorage@1"
+                },
+                {
+                    "command": "azureStorage.uploadFolder",
+                    "when": "explorerResourceIsFolder == true",
                     "group": "zzzz_azurestorage@1"
                 }
             ],
@@ -453,9 +458,14 @@
                     "group": "2_create@1"
                 },
                 {
-                    "command": "azureStorage.uploadFile",
+                    "command": "azureStorage.uploadFiles",
                     "when": "view == azureStorage && viewItem == azureBlobContainer",
                     "group": "2_create@2"
+                },
+                {
+                    "command": "azureStorage.uploadFolder",
+                    "when": "view == azureStorage && viewItem == azureBlobContainer",
+                    "group": "2_create@3"
                 },
                 {
                     "command": "azureStorage.copyUrl",
@@ -535,9 +545,14 @@
                     "group": "2_create@2"
                 },
                 {
-                    "command": "azureStorage.uploadFile",
+                    "command": "azureStorage.uploadFiles",
                     "when": "view == azureStorage && viewItem == azureFileShare",
                     "group": "2_create@3"
+                },
+                {
+                    "command": "azureStorage.uploadFolder",
+                    "when": "view == azureStorage && viewItem == azureFileShare",
+                    "group": "2_create@4"
                 },
                 {
                     "command": "azureStorage.createGpv2Account",
@@ -681,10 +696,6 @@
                 },
                 {
                     "command": "azureStorage.createBlockBlob",
-                    "when": "never"
-                },
-                {
-                    "command": "azureStorage.uploadFile",
                     "when": "never"
                 },
                 {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
         "onCommand:azureStorage.createBlobContainer",
         "onCommand:azureStorage.deleteBlobContainer",
         "onCommand:azureStorage.createBlockBlob",
+        "onCommand:azureStorage.uploadFolder",
         "onCommand:azureStorage.uploadFiles",
         "onCommand:azureStorage.deleteBlob",
         "onCommand:azureStorage.downloadBlob",
@@ -69,7 +70,7 @@
         "onCommand:azureStorage.deleteTable",
         "onCommand:azureStorage.createQueue",
         "onCommand:azureStorage.deleteQueue",
-        "onCommand:azureStorage.uploadFolder",
+        "onCommand:azureStorage.uploadToAzureStorage",
         "onCommand:azureStorage.attachStorageAccount",
         "onCommand:azureStorage.detachStorageAccount",
         "onCommand:azureStorage.startBlobEmulator",
@@ -209,6 +210,11 @@
                 "category": "Azure Storage"
             },
             {
+                "command": "azureStorage.uploadFolder",
+                "title": "Upload Folder...",
+                "category": "Azure Storage"
+            },
+            {
                 "command": "azureStorage.uploadFiles",
                 "title": "Upload Files...",
                 "category": "Azure Storage"
@@ -298,8 +304,8 @@
                 "category": "Azure Storage"
             },
             {
-                "command": "azureStorage.uploadFolder",
-                "title": "Upload Folder...",
+                "command": "azureStorage.uploadToAzureStorage",
+                "title": "Upload to Azure Storage...",
                 "category": "Azure Storage"
             },
             {
@@ -357,13 +363,8 @@
                     "group": "zzz_azuretools_deploy@3"
                 },
                 {
-                    "command": "azureStorage.uploadFiles",
-                    "when": "isFileSystemResource == true && explorerResourceIsFolder == false",
-                    "group": "zzzz_azurestorage@1"
-                },
-                {
-                    "command": "azureStorage.uploadFolder",
-                    "when": "explorerResourceIsFolder == true",
+                    "command": "azureStorage.uploadToAzureStorage",
+                    "when": "isFileSystemResource == true",
                     "group": "zzzz_azurestorage@1"
                 }
             ],
@@ -744,6 +745,10 @@
                 },
                 {
                     "command": "azureStorage.startQueueEmulator",
+                    "when": "never"
+                },
+                {
+                    "command": "azureStorage.uploadToAzureStorage",
                     "when": "never"
                 }
             ]

--- a/src/TransferProgress.ts
+++ b/src/TransferProgress.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as vscode from 'vscode';
+import { NotificationProgress } from './constants';
 import { ext } from './extensionVariables';
 
 export class TransferProgress {
@@ -18,13 +18,7 @@ export class TransferProgress {
         private readonly updateTimerMs: number = 200
     ) { }
 
-    public reportToNotification(
-        finishedWork: number,
-        notificationProgress: vscode.Progress<{
-            message?: string | undefined;
-            increment?: number | undefined;
-        }>
-    ): void {
+    public reportToNotification(finishedWork: number, notificationProgress: NotificationProgress): void {
         // This function may be called very frequently. Calls made to notificationProgress.report too rapidly result in incremental
         // progress not displaying in the notification window. So debounce calls to notificationProgress.report
         if (this.lastUpdated + this.updateTimerMs < Date.now()) {

--- a/src/commands/azCopy/azCopyTransfer.ts
+++ b/src/commands/azCopy/azCopyTransfer.ts
@@ -4,8 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AzCopyClient, AzCopyLocation, FromToOption, IAzCopyClient, ICopyOptions, ILocalLocation, IRemoteSasLocation, TransferStatus } from "@azure-tools/azcopy-node";
-import { CancellationToken, Progress } from 'vscode';
+import { CancellationToken } from 'vscode';
 import { IActionContext } from "vscode-azureextensionui";
+import { NotificationProgress } from "../../constants";
 import { ext } from '../../extensionVariables';
 import { TransferProgress } from "../../TransferProgress";
 import { delay } from "../../utils/delay";
@@ -18,10 +19,7 @@ export async function azCopyTransfer(
     src: ILocalLocation,
     dst: IRemoteSasLocation,
     transferProgress: TransferProgress,
-    notificationProgress?: Progress<{
-        message?: string | undefined;
-        increment?: number | undefined;
-    }>,
+    notificationProgress?: NotificationProgress,
     cancellationToken?: CancellationToken
 ): Promise<void> {
     const copyClient: AzCopyClient = new AzCopyClient();
@@ -69,10 +67,7 @@ async function startAndWaitForCopy(
     dst: AzCopyLocation,
     options: ICopyOptions,
     transferProgress: TransferProgress,
-    notificationProgress?: Progress<{
-        message?: string | undefined;
-        increment?: number | undefined;
-    }>,
+    notificationProgress?: NotificationProgress,
     cancellationToken?: CancellationToken
 ): Promise<string> {
     let jobId: string = await copyClient.copy(src, dst, options);

--- a/src/commands/uploadFile.ts
+++ b/src/commands/uploadFile.ts
@@ -4,51 +4,65 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { basename } from "path";
-import { OpenDialogOptions, Uri, window } from "vscode";
+import { Uri, window } from "vscode";
 import { IActionContext } from "vscode-azureextensionui";
+import { ext } from "../extensionVariables";
 import { BlobContainerTreeItem } from "../tree/blob/BlobContainerTreeItem";
 import { FileShareTreeItem } from "../tree/fileShare/FileShareTreeItem";
-import { localize } from "../utils/localize";
-import { validateFileName } from "../utils/validateNames";
+import { getBlobPath } from "../utils/blobUtils";
+import { getFileName } from "../utils/fileUtils";
+import { upload } from "../utils/uploadUtils";
 
-let lastUploadFolder: Uri;
+let lastUriUpload: Uri;
 
 export interface IExistingFileContext extends IActionContext {
     localFilePath: string;
     remoteFilePath: string;
 }
 
-export async function uploadFile(context: IActionContext, treeItem: BlobContainerTreeItem | FileShareTreeItem): Promise<void> {
-    const uris: Uri[] | undefined = await window.showOpenDialog(
-        <OpenDialogOptions>{
-            canSelectFiles: true,
-            canSelectFolders: false,
-            canSelectMany: false,
-            defaultUri: lastUploadFolder,
-            filters: {
-                "All files": ['*']
-            },
-            openLabel: "Upload"
-        }
-    );
-    if (uris && uris.length) {
-        const uri: Uri = uris[0];
-        lastUploadFolder = uri;
-        const localFilePath: string = uri.fsPath;
-        const remoteFilePath = await window.showInputBox({
-            prompt: localize('enterNameForFile', 'Enter a name for the uploaded file'),
-            value: basename(localFilePath),
-            validateInput: treeItem instanceof BlobContainerTreeItem ? BlobContainerTreeItem.validateBlobName : validateFileName
-        });
-        if (remoteFilePath) {
-            const id: string = `${treeItem.fullId}/${remoteFilePath}`;
-            const result = await treeItem.treeDataProvider.findTreeItem(id, context);
-            if (result) {
-                // A treeItem for this file already exists, no need to do anything with the tree, just upload
-                await treeItem.uploadLocalFile(context, localFilePath, remoteFilePath);
-                return;
+export async function uploadFiles(context: IActionContext, treeItem?: BlobContainerTreeItem | FileShareTreeItem, uris?: Uri[]): Promise<void> {
+    if (!uris) {
+        uris = await window.showOpenDialog(
+            {
+                canSelectFiles: true,
+                canSelectFolders: false,
+                canSelectMany: true,
+                defaultUri: lastUriUpload,
+                filters: {
+                    "All files": ['*']
+                },
+                openLabel: upload
             }
-            await treeItem.createChild(<IExistingFileContext>{ ...context, remoteFilePath, localFilePath });
+        );
+    }
+
+    if (!(treeItem instanceof BlobContainerTreeItem) && !(treeItem instanceof FileShareTreeItem)) {
+        treeItem = <BlobContainerTreeItem | FileShareTreeItem>(await ext.tree.showTreeItemPicker([BlobContainerTreeItem.contextValue, FileShareTreeItem.contextValue], context));
+    }
+
+    if (uris && uris.length) {
+        lastUriUpload = uris[0];
+        for (const uri of uris) {
+            const localFilePath: string = uri.fsPath;
+            let remoteFilePath: string | undefined = basename(localFilePath);
+
+            // Only prompt for upload name if we're uploading a single file
+            if (uris.length === 1) {
+                remoteFilePath = treeItem instanceof BlobContainerTreeItem ?
+                    await getBlobPath(treeItem, remoteFilePath) :
+                    await getFileName(treeItem, '', treeItem.shareName, remoteFilePath);
+            }
+
+            if (remoteFilePath) {
+                const id: string = `${treeItem.fullId}/${remoteFilePath}`;
+                const result = await treeItem.treeDataProvider.findTreeItem(id, context);
+                if (result) {
+                    // A treeItem for this file already exists, no need to do anything with the tree, just upload
+                    await treeItem.uploadLocalFile(context, localFilePath, remoteFilePath);
+                    continue;
+                }
+                await treeItem.createChild(<IExistingFileContext>{ ...context, remoteFilePath, localFilePath });
+            }
         }
     }
 }

--- a/src/commands/uploadFolder.ts
+++ b/src/commands/uploadFolder.ts
@@ -51,11 +51,11 @@ export async function uploadFolder(
     }
 
     if (notificationProgress && cancellationToken) {
+        // AzCopy recognizes folders as a resource when uploading to file shares. So only set `countFoldersAsResources=true` in that case
         await uploadLocalFolder(actionContext, treeItem, sourcePath, destPath, notificationProgress, cancellationToken, destPath, treeItem instanceof FileShareTreeItem);
     } else {
         const title: string = getUploadingMessageWithSource(sourcePath, treeItem.label);
         await vscode.window.withProgress({ cancellable: true, location: vscode.ProgressLocation.Notification, title }, async (newNotificationProgress, newCancellationToken) => {
-            // AzCopy recognizes folders as a resource when uploading to file shares. So only set `countFoldersAsResources=true` in that case
             // tslint:disable-next-line:no-non-null-assertion
             await uploadLocalFolder(actionContext, treeItem!, sourcePath, destPath, newNotificationProgress, newCancellationToken, destPath, treeItem instanceof FileShareTreeItem);
         });

--- a/src/commands/uploadFolder.ts
+++ b/src/commands/uploadFolder.ts
@@ -1,0 +1,67 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { basename } from 'path';
+import * as vscode from 'vscode';
+import { IActionContext } from 'vscode-azureextensionui';
+import { ext } from '../extensionVariables';
+import { BlobContainerTreeItem } from '../tree/blob/BlobContainerTreeItem';
+import { FileShareTreeItem } from '../tree/fileShare/FileShareTreeItem';
+import { getBlobPath } from '../utils/blobUtils';
+import { getFileName } from '../utils/fileUtils';
+import { localize } from '../utils/localize';
+import { getUploadingMessageWithSource, upload, uploadLocalFolder } from '../utils/uploadUtils';
+
+export async function uploadFolder(
+    actionContext: IActionContext,
+    treeItem?: BlobContainerTreeItem | FileShareTreeItem,
+    uri?: vscode.Uri,
+    notificationProgress?: vscode.Progress<{
+        message?: string | undefined;
+        increment?: number | undefined;
+    }>,
+    cancellationToken?: vscode.CancellationToken,
+    suppressPrompts?: boolean
+): Promise<void> {
+    if (uri?.scheme === 'azurestorage') {
+        throw new Error(localize('cannotUploadToAzureFromAzureResource', 'Cannot upload to Azure from an Azure resource.'));
+    }
+
+    // tslint:disable: strict-boolean-expressions
+    uri = uri || (await ext.ui.showOpenDialog({
+        canSelectFiles: false,
+        canSelectFolders: true,
+        canSelectMany: false,
+        defaultUri: vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0 ? vscode.workspace.workspaceFolders[0].uri : undefined,
+        openLabel: upload
+    }))[0];
+
+    treeItem = treeItem || <BlobContainerTreeItem | FileShareTreeItem>(await ext.tree.showTreeItemPicker([BlobContainerTreeItem.contextValue, FileShareTreeItem.contextValue], actionContext));
+    // tslint:enable: strict-boolean-expressions
+
+    const sourcePath: string = uri.fsPath;
+    let destPath: string = basename(sourcePath);
+    if (!suppressPrompts) {
+        destPath = treeItem instanceof BlobContainerTreeItem ?
+            await getBlobPath(treeItem, destPath) :
+            await getFileName(treeItem, '', treeItem.shareName, destPath);
+        await showUploadWarning(localize('uploadWillOverwrite', 'Uploading "{0}" will overwrite any existing resources with the same name.', sourcePath));
+    }
+
+    if (notificationProgress && cancellationToken) {
+        await uploadLocalFolder(actionContext, treeItem, sourcePath, destPath, notificationProgress, cancellationToken, destPath, treeItem instanceof FileShareTreeItem);
+    } else {
+        const title: string = getUploadingMessageWithSource(sourcePath, treeItem.label);
+        await vscode.window.withProgress({ cancellable: true, location: vscode.ProgressLocation.Notification, title }, async (newNotificationProgress, newCancellationToken) => {
+            // AzCopy recognizes folders as a resource when uploading to file shares. So only set `countFoldersAsResources=true` in that case
+            // tslint:disable-next-line:no-non-null-assertion
+            await uploadLocalFolder(actionContext, treeItem!, sourcePath, destPath, newNotificationProgress, newCancellationToken, destPath, treeItem instanceof FileShareTreeItem);
+        });
+    }
+}
+
+async function showUploadWarning(message: string): Promise<void> {
+    await ext.ui.showWarningMessage(message, { modal: true }, { title: localize('upload', 'Upload') });
+}

--- a/src/commands/uploadToAzureStorage.ts
+++ b/src/commands/uploadToAzureStorage.ts
@@ -9,19 +9,20 @@ import { IActionContext } from 'vscode-azureextensionui';
 import { ext } from '../extensionVariables';
 import { BlobContainerTreeItem } from '../tree/blob/BlobContainerTreeItem';
 import { FileShareTreeItem } from '../tree/fileShare/FileShareTreeItem';
+import { throwIfCanceled } from '../utils/errorUtils';
 import { localize } from '../utils/localize';
 import { getUploadingMessage, showUploadWarning } from '../utils/uploadUtils';
 import { uploadFiles } from './uploadFile';
 import { uploadFolder } from './uploadFolder';
 
 export async function uploadToAzureStorage(actionContext: IActionContext, _firstSelection: vscode.Uri, uris: vscode.Uri[]): Promise<void> {
-    if (uris.length && uris[0].scheme === 'azurestorage') {
-        throw new Error(localize('cannotUploadToAzureFromAzureResource', 'Cannot upload to Azure from an Azure resource.'));
-    }
-
     const folderUris: vscode.Uri[] = [];
     const fileUris: vscode.Uri[] = [];
     for (const uri of uris) {
+        if (uri.scheme === 'azurestorage') {
+            throw new Error(localize('cannotUploadToAzureFromAzureResource', 'Cannot upload to Azure from an Azure resource.'));
+        }
+
         if ((await stat(uri.fsPath)).isDirectory()) {
             folderUris.push(uri);
         } else {
@@ -30,11 +31,12 @@ export async function uploadToAzureStorage(actionContext: IActionContext, _first
     }
 
     const treeItem: BlobContainerTreeItem | FileShareTreeItem = await ext.tree.showTreeItemPicker([BlobContainerTreeItem.contextValue, FileShareTreeItem.contextValue], actionContext);
-    const suppressPrompts: boolean = uris.length > 1;
     const title: string = getUploadingMessage(treeItem.label);
     await showUploadWarning(localize('uploadingToWillOverwrite', 'Uploading to "{0}" will overwrite any existing resources with the same name.', treeItem.label));
     await vscode.window.withProgress({ cancellable: true, location: vscode.ProgressLocation.Notification, title }, async (notificationProgress, cancellationToken) => {
+        const suppressPrompts: boolean = uris.length > 1;
         for (const folderUri of folderUris) {
+            throwIfCanceled(cancellationToken, actionContext.telemetry.properties, 'uploadToAzureStorage');
             await uploadFolder(actionContext, treeItem, folderUri, notificationProgress, cancellationToken, suppressPrompts);
         }
 

--- a/src/commands/uploadToAzureStorage.ts
+++ b/src/commands/uploadToAzureStorage.ts
@@ -31,10 +31,14 @@ export async function uploadToAzureStorage(actionContext: IActionContext, _first
     }
 
     const treeItem: BlobContainerTreeItem | FileShareTreeItem = await ext.tree.showTreeItemPicker([BlobContainerTreeItem.contextValue, FileShareTreeItem.contextValue], actionContext);
+    const suppressPrompts: boolean = uris.length > 1;
+    if (suppressPrompts) {
+        // Suppressing prompts in `uploadFolder` and `uploadFile` means we need to prompt here
+        await showUploadWarning(localize('uploadingToWillOverwrite', 'Uploading to "{0}" will overwrite any existing resources with the same name.', treeItem.label));
+    }
+
     const title: string = getUploadingMessage(treeItem.label);
-    await showUploadWarning(localize('uploadingToWillOverwrite', 'Uploading to "{0}" will overwrite any existing resources with the same name.', treeItem.label));
     await vscode.window.withProgress({ cancellable: true, location: vscode.ProgressLocation.Notification, title }, async (notificationProgress, cancellationToken) => {
-        const suppressPrompts: boolean = uris.length > 1;
         for (const folderUri of folderUris) {
             throwIfCanceled(cancellationToken, actionContext.telemetry.properties, 'uploadToAzureStorage');
             await uploadFolder(actionContext, treeItem, folderUri, notificationProgress, cancellationToken, suppressPrompts);

--- a/src/commands/uploadToAzureStorage.ts
+++ b/src/commands/uploadToAzureStorage.ts
@@ -10,11 +10,15 @@ import { ext } from '../extensionVariables';
 import { BlobContainerTreeItem } from '../tree/blob/BlobContainerTreeItem';
 import { FileShareTreeItem } from '../tree/fileShare/FileShareTreeItem';
 import { localize } from '../utils/localize';
-import { getUploadingMessage } from '../utils/uploadUtils';
+import { getUploadingMessage, showUploadWarning } from '../utils/uploadUtils';
 import { uploadFiles } from './uploadFile';
 import { uploadFolder } from './uploadFolder';
 
 export async function uploadToAzureStorage(actionContext: IActionContext, _firstSelection: vscode.Uri, uris: vscode.Uri[]): Promise<void> {
+    if (uris.length && uris[0].scheme === 'azurestorage') {
+        throw new Error(localize('cannotUploadToAzureFromAzureResource', 'Cannot upload to Azure from an Azure resource.'));
+    }
+
     const folderUris: vscode.Uri[] = [];
     const fileUris: vscode.Uri[] = [];
     for (const uri of uris) {
@@ -26,13 +30,15 @@ export async function uploadToAzureStorage(actionContext: IActionContext, _first
     }
 
     const treeItem: BlobContainerTreeItem | FileShareTreeItem = await ext.tree.showTreeItemPicker([BlobContainerTreeItem.contextValue, FileShareTreeItem.contextValue], actionContext);
+    const suppressPrompts: boolean = uris.length > 1;
     const title: string = getUploadingMessage(treeItem.label);
+    await showUploadWarning(localize('uploadingToWillOverwrite', 'Uploading to "{0}" will overwrite any existing resources with the same name.', treeItem.label));
     await vscode.window.withProgress({ cancellable: true, location: vscode.ProgressLocation.Notification, title }, async (notificationProgress, cancellationToken) => {
         for (const folderUri of folderUris) {
-            await uploadFolder(actionContext, treeItem, folderUri, notificationProgress, cancellationToken, true);
+            await uploadFolder(actionContext, treeItem, folderUri, notificationProgress, cancellationToken, suppressPrompts);
         }
 
-        await uploadFiles(actionContext, treeItem, fileUris, notificationProgress, cancellationToken);
+        await uploadFiles(actionContext, treeItem, fileUris, notificationProgress, cancellationToken, suppressPrompts);
     });
 
     const success: string = localize('successfullyUploaded', 'Successfully uploaded to "{0}"', treeItem.label);

--- a/src/commands/uploadToAzureStorage.ts
+++ b/src/commands/uploadToAzureStorage.ts
@@ -3,60 +3,39 @@
  *  Licensed under the MIT License. See License.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { basename } from 'path';
+import { stat } from 'fs-extra';
 import * as vscode from 'vscode';
 import { IActionContext } from 'vscode-azureextensionui';
 import { ext } from '../extensionVariables';
 import { BlobContainerTreeItem } from '../tree/blob/BlobContainerTreeItem';
 import { FileShareTreeItem } from '../tree/fileShare/FileShareTreeItem';
-import { getBlobPath } from '../utils/blobUtils';
-import { getFileName } from '../utils/fileUtils';
 import { localize } from '../utils/localize';
-import { getUploadingMessage, upload, uploadLocalFolder } from '../utils/uploadUtils';
+import { getUploadingMessage } from '../utils/uploadUtils';
+import { uploadFiles } from './uploadFile';
+import { uploadFolder } from './uploadFolder';
 
-export async function uploadFolder(actionContext: IActionContext, target?: vscode.Uri | BlobContainerTreeItem | FileShareTreeItem): Promise<void> {
-    let uri: vscode.Uri;
-    if (target instanceof vscode.Uri) {
-        uri = target;
-        if (uri.scheme === 'azurestorage') {
-            throw new Error(localize('cannotUploadToAzureFromAzureResource', 'Cannot upload to Azure from an Azure resource.'));
+export async function uploadToAzureStorage(actionContext: IActionContext, _firstSelection: vscode.Uri, uris: vscode.Uri[]): Promise<void> {
+    const folderUris: vscode.Uri[] = [];
+    const fileUris: vscode.Uri[] = [];
+    for (const uri of uris) {
+        if ((await stat(uri.fsPath)).isDirectory()) {
+            folderUris.push(uri);
+        } else {
+            fileUris.push(uri);
         }
-    } else {
-        uri = (await ext.ui.showOpenDialog({
-            canSelectFiles: false,
-            canSelectFolders: true,
-            canSelectMany: false,
-            defaultUri: vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0 ? vscode.workspace.workspaceFolders[0].uri : undefined,
-            openLabel: upload
-        }))[0];
     }
 
-    let treeItem: BlobContainerTreeItem | FileShareTreeItem;
-    if (target instanceof BlobContainerTreeItem || target instanceof FileShareTreeItem) {
-        treeItem = target;
-    } else {
-        treeItem = await ext.tree.showTreeItemPicker([BlobContainerTreeItem.contextValue, FileShareTreeItem.contextValue], actionContext);
-    }
-
-    const title: string = getUploadingMessage(uri.fsPath, treeItem.label);
+    const treeItem: BlobContainerTreeItem | FileShareTreeItem = await ext.tree.showTreeItemPicker([BlobContainerTreeItem.contextValue, FileShareTreeItem.contextValue], actionContext);
+    const title: string = getUploadingMessage(treeItem.label);
     await vscode.window.withProgress({ cancellable: true, location: vscode.ProgressLocation.Notification, title }, async (notificationProgress, cancellationToken) => {
-        const sourcePath: string = uri.fsPath;
-        await showUploadWarning(localize('uploadWillOverwrite', 'Uploading "{0}" will overwrite any existing resources with the same name.', sourcePath));
+        for (const folderUri of folderUris) {
+            await uploadFolder(actionContext, treeItem, folderUri, notificationProgress, cancellationToken, true);
+        }
 
-        const destFileName: string = basename(sourcePath);
-        const destPath: string = treeItem instanceof BlobContainerTreeItem ?
-            await getBlobPath(treeItem, destFileName) :
-            await getFileName(treeItem, '', treeItem.shareName, destFileName);
-
-        // AzCopy recognizes folders as a resource when uploading to file shares. So only set `countFoldersAsResources=true` in that case
-        await uploadLocalFolder(actionContext, treeItem, sourcePath, destPath, notificationProgress, cancellationToken, destPath, treeItem instanceof FileShareTreeItem);
+        await uploadFiles(actionContext, treeItem, fileUris, notificationProgress, cancellationToken);
     });
 
     const success: string = localize('successfullyUploaded', 'Successfully uploaded to "{0}"', treeItem.label);
     ext.outputChannel.appendLog(success);
     vscode.window.showInformationMessage(success);
-}
-
-async function showUploadWarning(message: string): Promise<void> {
-    await ext.ui.showWarningMessage(message, { modal: true }, { title: localize('upload', 'Upload') });
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { Progress } from 'vscode';
 import { ext } from './extensionVariables';
 
 export const staticWebsiteContainerName = '$web';
@@ -23,3 +24,8 @@ export const emulatorKey: string = 'Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6
 export function getResourcesPath(): string {
     return ext.context.asAbsolutePath('resources');
 }
+
+export type NotificationProgress = Progress<{
+    message?: string | undefined;
+    increment?: number | undefined;
+}>;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,8 +30,8 @@ import { emulatorTimeoutMS as startEmulatorDebounce, EmulatorType, startEmulator
 import { registerStorageAccountActionHandlers } from './commands/storageAccountActionHandlers';
 import { registerTableActionHandlers } from './commands/table/tableActionHandlers';
 import { registerTableGroupActionHandlers } from './commands/table/tableGroupActionHandlers';
-import { uploadFile } from './commands/uploadFile';
-import { uploadToAzureStorage } from './commands/uploadToAzureStorage';
+import { uploadFiles } from './commands/uploadFile';
+import { uploadFolder } from './commands/uploadToAzureStorage';
 import { ext } from './extensionVariables';
 import { AzureAccountTreeItem } from './tree/AzureAccountTreeItem';
 import { BlobContainerTreeItem } from './tree/blob/BlobContainerTreeItem';
@@ -135,8 +135,8 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
             await accountTreeItem.browseStaticWebsite();
         });
     });
-    registerCommand("azureStorage.uploadToAzureStorage", uploadToAzureStorage);
-    registerCommand("azureStorage.uploadFile", uploadFile);
+    registerCommand("azureStorage.uploadFolder", uploadFolder);
+    registerCommand("azureStorage.uploadFiles", uploadFiles);
     registerCommand("azureStorage.attachStorageAccount", async () => {
         await ext.attachedStorageAccountsTreeItem.attachWithConnectionString();
     });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,7 +31,8 @@ import { registerStorageAccountActionHandlers } from './commands/storageAccountA
 import { registerTableActionHandlers } from './commands/table/tableActionHandlers';
 import { registerTableGroupActionHandlers } from './commands/table/tableGroupActionHandlers';
 import { uploadFiles } from './commands/uploadFile';
-import { uploadFolder } from './commands/uploadToAzureStorage';
+import { uploadFolder } from './commands/uploadFolder';
+import { uploadToAzureStorage } from './commands/uploadToAzureStorage';
 import { ext } from './extensionVariables';
 import { AzureAccountTreeItem } from './tree/AzureAccountTreeItem';
 import { BlobContainerTreeItem } from './tree/blob/BlobContainerTreeItem';
@@ -137,6 +138,7 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
     });
     registerCommand("azureStorage.uploadFolder", uploadFolder);
     registerCommand("azureStorage.uploadFiles", uploadFiles);
+    registerCommand("azureStorage.uploadToAzureStorage", uploadToAzureStorage);
     registerCommand("azureStorage.attachStorageAccount", async () => {
         await ext.attachedStorageAccountsTreeItem.attachWithConnectionString();
     });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -136,8 +136,8 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
             await accountTreeItem.browseStaticWebsite();
         });
     });
-    registerCommand("azureStorage.uploadFolder", uploadFolder);
     registerCommand("azureStorage.uploadFiles", uploadFiles);
+    registerCommand("azureStorage.uploadFolder", uploadFolder);
     registerCommand("azureStorage.uploadToAzureStorage", uploadToAzureStorage);
     registerCommand("azureStorage.attachStorageAccount", async () => {
         await ext.attachedStorageAccountsTreeItem.attachWithConnectionString();

--- a/src/tree/blob/BlobContainerTreeItem.ts
+++ b/src/tree/blob/BlobContainerTreeItem.ts
@@ -17,9 +17,9 @@ import { IExistingFileContext } from '../../commands/uploadFile';
 import { getResourcesPath, staticWebsiteContainerName } from "../../constants";
 import { ext } from "../../extensionVariables";
 import { TransferProgress } from '../../TransferProgress';
-import { createBlobContainerClient, createChildAsNewBlockBlob, doesBlobExist, getBlobPath, IBlobContainerCreateChildContext, loadMoreBlobChildren } from '../../utils/blobUtils';
+import { createBlobContainerClient, createChildAsNewBlockBlob, IBlobContainerCreateChildContext, loadMoreBlobChildren } from '../../utils/blobUtils';
 import { throwIfCanceled } from '../../utils/errorUtils';
-import { getUploadingMessage, uploadFiles, warnFileAlreadyExists } from '../../utils/uploadUtils';
+import { getUploadingMessage, uploadLocalFolder } from '../../utils/uploadUtils';
 import { ICopyUrl } from '../ICopyUrl';
 import { IStorageRoot } from "../IStorageRoot";
 import { StorageAccountTreeItem } from "../StorageAccountTreeItem";
@@ -230,7 +230,7 @@ export class BlobContainerTreeItem extends AzureParentTreeItem<IStorageRoot> imp
             notificationProgress.report({ increment: -1 });
 
             // Upload files as blobs
-            await uploadFiles(context, this, sourceFolderPath, destBlobFolder, notificationProgress, cancellationToken, 'Uploading', false);
+            await uploadLocalFolder(context, this, sourceFolderPath, destBlobFolder, notificationProgress, cancellationToken, 'Uploading', false);
 
             let webEndpoint = this.getPrimaryWebEndpoint();
             if (!webEndpoint) {
@@ -301,14 +301,7 @@ export class BlobContainerTreeItem extends AzureParentTreeItem<IStorageRoot> imp
         }
     }
 
-    public async uploadLocalFile(context: IActionContext, filePath: string, blobPath: string, suppressPrompts: boolean = false): Promise<void> {
-        if (!suppressPrompts) {
-            blobPath = blobPath !== undefined ? blobPath : await getBlobPath(this, blobPath);
-            if (await doesBlobExist(this, blobPath)) {
-                await warnFileAlreadyExists(blobPath);
-            }
-        }
-
+    public async uploadLocalFile(context: IActionContext, filePath: string, blobPath: string): Promise<void> {
         ext.outputChannel.appendLog(getUploadingMessage(filePath, this.label));
         const src: ILocalLocation = createAzCopyLocalSource(filePath);
         const dst: IRemoteSasLocation = createAzCopyDestination(this, blobPath);

--- a/src/tree/blob/BlobContainerTreeItem.ts
+++ b/src/tree/blob/BlobContainerTreeItem.ts
@@ -14,7 +14,7 @@ import { AzureStorageFS } from '../../AzureStorageFS';
 import { createAzCopyDestination, createAzCopyLocalSource } from '../../commands/azCopy/azCopyLocations';
 import { azCopyTransfer } from '../../commands/azCopy/azCopyTransfer';
 import { IExistingFileContext } from '../../commands/uploadFile';
-import { getResourcesPath, staticWebsiteContainerName } from "../../constants";
+import { getResourcesPath, NotificationProgress, staticWebsiteContainerName } from "../../constants";
 import { ext } from "../../extensionVariables";
 import { TransferProgress } from '../../TransferProgress';
 import { createBlobContainerClient, createChildAsNewBlockBlob, IBlobContainerCreateChildContext, loadMoreBlobChildren } from '../../utils/blobUtils';
@@ -202,7 +202,7 @@ export class BlobContainerTreeItem extends AzureParentTreeItem<IStorageRoot> imp
         context: IActionContext,
         sourceFolderPath: string,
         destBlobFolder: string,
-        notificationProgress: vscode.Progress<{ message?: string, increment?: number }>,
+        notificationProgress: NotificationProgress,
         cancellationToken: vscode.CancellationToken
     ): Promise<string> {
         try {
@@ -270,10 +270,7 @@ export class BlobContainerTreeItem extends AzureParentTreeItem<IStorageRoot> imp
     private async deleteBlobs(
         blobsToDelete: azureStorageBlob.BlobItem[],
         transferProgress: TransferProgress,
-        notificationProgress: vscode.Progress<{
-            message?: string | undefined;
-            increment?: number | undefined;
-        }>,
+        notificationProgress: NotificationProgress,
         cancellationToken: vscode.CancellationToken,
         properties: TelemetryProperties,
     ): Promise<void> {
@@ -305,10 +302,7 @@ export class BlobContainerTreeItem extends AzureParentTreeItem<IStorageRoot> imp
         context: IActionContext,
         filePath: string,
         blobPath: string,
-        notificationProgress?: vscode.Progress<{
-            message?: string | undefined;
-            increment?: number | undefined;
-        }>,
+        notificationProgress?: NotificationProgress,
         cancellationToken?: vscode.CancellationToken
     ): Promise<void> {
         ext.outputChannel.appendLog(getUploadingMessageWithSource(filePath, this.label));

--- a/src/tree/createWizard/StaticWebsiteConfigureStep.ts
+++ b/src/tree/createWizard/StaticWebsiteConfigureStep.ts
@@ -4,8 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as azureStorageBlob from '@azure/storage-blob';
-import { Progress, window } from "vscode";
+import { window } from "vscode";
 import { AzureWizardExecuteStep } from "vscode-azureextensionui";
+import { NotificationProgress } from '../../constants';
 import { ext } from '../../extensionVariables';
 import { localize } from '../../utils/localize';
 import { StorageAccountTreeItem } from "../StorageAccountTreeItem";
@@ -23,7 +24,7 @@ export class StaticWebsiteConfigureStep extends AzureWizardExecuteStep<IStorageA
         this.previouslyEnabled = previouslyEnabled;
     }
 
-    public async execute(wizardContext: IStorageAccountTreeItemCreateContext & IStaticWebsiteConfigWizardContext, progress: Progress<{ message?: string; increment?: number }>): Promise<void> {
+    public async execute(wizardContext: IStorageAccountTreeItemCreateContext & IStaticWebsiteConfigWizardContext, progress: NotificationProgress): Promise<void> {
         // tslint:disable-next-line: strict-boolean-expressions
         this.accountTreeItem = this.accountTreeItem || wizardContext.accountTreeItem;
 

--- a/src/tree/createWizard/storageAccountCreateStep.ts
+++ b/src/tree/createWizard/storageAccountCreateStep.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { StorageManagementClient, StorageManagementModels } from '@azure/arm-storage';
-import { Progress } from 'vscode';
 import { AzureWizardExecuteStep, createAzureClient, INewStorageAccountDefaults, IStorageAccountWizardContext } from 'vscode-azureextensionui';
+import { NotificationProgress } from '../../constants';
 import { ext } from '../../extensionVariables';
 
 export class StorageAccountCreateStep<T extends IStorageAccountWizardContext> extends AzureWizardExecuteStep<T> implements StorageAccountCreateStep<T> {
@@ -18,7 +18,7 @@ export class StorageAccountCreateStep<T extends IStorageAccountWizardContext> ex
         this._defaults = defaults;
     }
 
-    public async execute(wizardContext: T, progress: Progress<{ message?: string; increment?: number }>): Promise<void> {
+    public async execute(wizardContext: T, progress: NotificationProgress): Promise<void> {
         // tslint:disable-next-line:no-non-null-assertion
         const newLocation: string = wizardContext.location!.name!;
         // tslint:disable-next-line:no-non-null-assertion

--- a/src/tree/fileShare/FileShareTreeItem.ts
+++ b/src/tree/fileShare/FileShareTreeItem.ts
@@ -14,7 +14,7 @@ import { AzureStorageFS } from "../../AzureStorageFS";
 import { createAzCopyDestination, createAzCopyLocalSource } from '../../commands/azCopy/azCopyLocations';
 import { azCopyTransfer } from '../../commands/azCopy/azCopyTransfer';
 import { IExistingFileContext } from '../../commands/uploadFile';
-import { getResourcesPath } from "../../constants";
+import { getResourcesPath, NotificationProgress } from "../../constants";
 import { ext } from "../../extensionVariables";
 import { TransferProgress } from '../../TransferProgress';
 import { askAndCreateChildDirectory, doesDirectoryExist, listFilesInDirectory } from '../../utils/directoryUtils';
@@ -121,10 +121,7 @@ export class FileShareTreeItem extends AzureParentTreeItem<IStorageRoot> impleme
         context: IActionContext,
         sourceFilePath: string,
         destFilePath: string,
-        notificationProgress?: vscode.Progress<{
-            message?: string | undefined;
-            increment?: number | undefined;
-        }>,
+        notificationProgress?: NotificationProgress,
         cancellationToken?: vscode.CancellationToken
     ): Promise<void> {
         const parentDirectoryPath: string = path.dirname(destFilePath);

--- a/src/tree/fileShare/FileShareTreeItem.ts
+++ b/src/tree/fileShare/FileShareTreeItem.ts
@@ -18,8 +18,8 @@ import { getResourcesPath } from "../../constants";
 import { ext } from "../../extensionVariables";
 import { TransferProgress } from '../../TransferProgress';
 import { askAndCreateChildDirectory, doesDirectoryExist, listFilesInDirectory } from '../../utils/directoryUtils';
-import { askAndCreateEmptyTextFile, createDirectoryClient, createShareClient, doesFileExist, getFileName } from '../../utils/fileUtils';
-import { getUploadingMessage, warnFileAlreadyExists } from '../../utils/uploadUtils';
+import { askAndCreateEmptyTextFile, createDirectoryClient, createShareClient } from '../../utils/fileUtils';
+import { getUploadingMessage } from '../../utils/uploadUtils';
 import { ICopyUrl } from '../ICopyUrl';
 import { IStorageRoot } from "../IStorageRoot";
 import { DirectoryTreeItem } from './DirectoryTreeItem';
@@ -117,16 +117,10 @@ export class FileShareTreeItem extends AzureParentTreeItem<IStorageRoot> impleme
         return child;
     }
 
-    public async uploadLocalFile(context: IActionContext, sourceFilePath: string, destFilePath: string, suppressPrompts: boolean = false): Promise<void> {
-        if (!suppressPrompts) {
-            destFilePath = destFilePath !== undefined ? destFilePath : await getFileName(this, path.dirname(sourceFilePath), this.shareName, destFilePath);
-            if (await doesFileExist(path.basename(destFilePath), this, path.dirname(destFilePath), this.shareName)) {
-                await warnFileAlreadyExists(destFilePath);
-            }
-        }
-
+    public async uploadLocalFile(context: IActionContext, sourceFilePath: string, destFilePath: string): Promise<void> {
         const parentDirectoryPath: string = path.dirname(destFilePath);
         const parentDirectories: string[] = parentDirectoryPath.split('/');
+
         ext.outputChannel.appendLog(getUploadingMessage(sourceFilePath, this.label));
 
         // Ensure parent directories exist before creating child files

--- a/src/utils/fileUtils.ts
+++ b/src/utils/fileUtils.ts
@@ -47,12 +47,15 @@ export async function getFileName(parent: AzureParentTreeItem<IStorageRoot>, dir
         value,
         placeHolder: 'Enter a name for the new file',
         validateInput: async (name: string) => {
+            if (await doesFileExist(name, parent, directoryPath, shareName)) {
+                return "A file with this path and name already exists";
+            }
+
             let nameError = validateFileName(name);
             if (nameError) {
                 return nameError;
-            } else if (await doesFileExist(name, parent, directoryPath, shareName)) {
-                return "A file with this path and name already exists";
             }
+
             return undefined;
         }
     });

--- a/src/utils/fileUtils.ts
+++ b/src/utils/fileUtils.ts
@@ -47,15 +47,12 @@ export async function getFileName(parent: AzureParentTreeItem<IStorageRoot>, dir
         value,
         placeHolder: 'Enter a name for the new file',
         validateInput: async (name: string) => {
-            if (await doesFileExist(name, parent, directoryPath, shareName)) {
-                return "A file with this path and name already exists";
-            }
-
             let nameError = validateFileName(name);
             if (nameError) {
                 return nameError;
+            } else if (await doesFileExist(name, parent, directoryPath, shareName)) {
+                return "A file with this path and name already exists";
             }
-
             return undefined;
         }
     });

--- a/src/utils/uploadUtils.ts
+++ b/src/utils/uploadUtils.ts
@@ -9,6 +9,7 @@ import * as vscode from 'vscode';
 import { IActionContext } from "vscode-azureextensionui";
 import { createAzCopyDestination, createAzCopyLocalSource } from '../commands/azCopy/azCopyLocations';
 import { azCopyTransfer } from '../commands/azCopy/azCopyTransfer';
+import { NotificationProgress } from '../constants';
 import { ext } from '../extensionVariables';
 import { TransferProgress } from '../TransferProgress';
 import { BlobContainerTreeItem } from '../tree/blob/BlobContainerTreeItem';
@@ -22,10 +23,7 @@ export async function uploadLocalFolder(
     destTreeItem: BlobContainerTreeItem | FileShareTreeItem,
     sourcePath: string,
     destPath: string,
-    notificationProgress: vscode.Progress<{
-        message?: string | undefined;
-        increment?: number | undefined;
-    }>,
+    notificationProgress: NotificationProgress,
     cancellationToken: vscode.CancellationToken,
     messagePrefix?: string,
     countFoldersAsResources?: boolean,
@@ -44,7 +42,11 @@ export function getUploadingMessage(treeItemLabel: string): string {
 }
 
 export function getUploadingMessageWithSource(sourcePath: string, treeItemLabel: string): string {
-    return localize('uploadingFromTo', 'Uploading "{0}" to "{1}"', sourcePath, treeItemLabel);
+    return localize('uploadingFromTo', 'Uploading from "{0}" to "{1}"', sourcePath, treeItemLabel);
+}
+
+export async function showUploadWarning(message: string): Promise<void> {
+    await ext.ui.showWarningMessage(message, { modal: true }, { title: upload });
 }
 
 async function getNumResourcesInDirectory(directoryPath: string, countFolders?: boolean): Promise<number> {

--- a/src/utils/uploadUtils.ts
+++ b/src/utils/uploadUtils.ts
@@ -35,12 +35,16 @@ export async function uploadLocalFolder(
     const dst: IRemoteSasLocation = createAzCopyDestination(destTreeItem, destPath);
     const totalWork: number = await getNumResourcesInDirectory(sourcePath, countFoldersAsResources);
     const transferProgress: TransferProgress = new TransferProgress(totalWork, messagePrefix);
-    ext.outputChannel.appendLog(getUploadingMessage(sourcePath, destTreeItem.label));
+    ext.outputChannel.appendLog(getUploadingMessageWithSource(sourcePath, destTreeItem.label));
     await azCopyTransfer(context, fromTo, src, dst, transferProgress, notificationProgress, cancellationToken);
 }
 
-export function getUploadingMessage(sourcePath: string, treeItemLabel: string): string {
-    return localize('uploading', 'Uploading "{0}" to "{1}"', sourcePath, treeItemLabel);
+export function getUploadingMessage(treeItemLabel: string): string {
+    return localize('uploadingTo', 'Uploading to "{0}"', treeItemLabel);
+}
+
+export function getUploadingMessageWithSource(sourcePath: string, treeItemLabel: string): string {
+    return localize('uploadingFromTo', 'Uploading "{0}" to "{1}"', sourcePath, treeItemLabel);
 }
 
 async function getNumResourcesInDirectory(directoryPath: string, countFolders?: boolean): Promise<number> {


### PR DESCRIPTION
I dialed back the functionality from https://github.com/microsoft/vscode-azurestorage/pull/760 to match what storage explorer does.

<img width="156" alt="Screen Shot 2020-09-04 at 1 45 37 PM" src="https://user-images.githubusercontent.com/22795803/92283559-fb8bf980-eeb4-11ea-9cc0-7e6e711f20db.png">

This keeps the code simpler and still lets users upload whatever combo of files/folders they need to. (If you want to upload multiple folders you can upload one folder containing all the other folders you want to upload)

Fixes https://github.com/microsoft/vscode-azurestorage/issues/623 once and for all 😤