### PR TITLE
Add overwrite prompts for resource uploads

### DIFF
--- a/src/commands/uploadFiles.ts
+++ b/src/commands/uploadFiles.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { basename } from "path";
 import { CancellationToken, ProgressLocation, Uri, window } from "vscode";
 import { IActionContext } from "vscode-azureextensionui";
 import { NotificationProgress } from "../constants";
@@ -12,7 +11,7 @@ import { BlobContainerTreeItem } from "../tree/blob/BlobContainerTreeItem";
 import { FileShareTreeItem } from "../tree/fileShare/FileShareTreeItem";
 import { throwIfCanceled } from "../utils/errorUtils";
 import { nonNullValue } from "../utils/nonNull";
-import { getUploadingMessage, OverwriteChoice, shouldUploadUri, upload } from "../utils/uploadUtils";
+import { convertLocalPathToRemotePath, getUploadingMessage, OverwriteChoice, shouldUploadUri, upload } from "../utils/uploadUtils";
 
 let lastUriUpload: Uri | undefined;
 
@@ -81,7 +80,7 @@ async function uploadFilesHelper(
         throwIfCanceled(cancellationToken, context.telemetry.properties, 'uploadFiles');
 
         const localFilePath: string = uri.fsPath;
-        const remoteFilePath: string = basename(localFilePath);
+        const remoteFilePath: string = convertLocalPathToRemotePath(localFilePath);
         const id: string = `${treeItem.fullId}/${remoteFilePath}`;
         const result = await treeItem.treeDataProvider.findTreeItem(id, context);
         if (result) {

--- a/src/commands/uploadFiles.ts
+++ b/src/commands/uploadFiles.ts
@@ -10,6 +10,7 @@ import { ext } from "../extensionVariables";
 import { BlobContainerTreeItem } from "../tree/blob/BlobContainerTreeItem";
 import { FileShareTreeItem } from "../tree/fileShare/FileShareTreeItem";
 import { throwIfCanceled } from "../utils/errorUtils";
+import { nonNullValue } from "../utils/nonNull";
 import { getRemoteResourceName, getUploadingMessage, OverwriteChoice, RemoteResourceNameMap, upload } from "../utils/uploadUtils";
 
 let lastUriUpload: Uri | undefined;
@@ -57,8 +58,8 @@ export async function uploadFiles(
     } else {
         const title: string = getUploadingMessage(treeItem.label);
         await window.withProgress({ cancellable: true, location: ProgressLocation.Notification, title }, async (newNotificationProgress, newCancellationToken) => {
-            // tslint:disable-next-line: strict-boolean-expressions no-non-null-assertion
-            await uploadFilesHelper(context, treeItem!, uris || [], remoteResourceNameMap!, newNotificationProgress, newCancellationToken);
+            // tslint:disable-next-line: strict-boolean-expressions
+            await uploadFilesHelper(context, nonNullValue(treeItem), uris || [], nonNullValue(remoteResourceNameMap), newNotificationProgress, newCancellationToken);
         });
     }
 }
@@ -75,8 +76,7 @@ async function uploadFilesHelper(
     for (const uri of uris) {
         throwIfCanceled(cancellationToken, context.telemetry.properties, 'uploadFiles');
 
-        // tslint:disable-next-line:no-non-null-assertion
-        const remoteFilePath: string = remoteResourceNameMap.get(uri)!;
+        const remoteFilePath: string = nonNullValue(remoteResourceNameMap.get(uri));
         const localFilePath: string = uri.fsPath;
         const id: string = `${treeItem.fullId}/${remoteFilePath}`;
         const result = await treeItem.treeDataProvider.findTreeItem(id, context);

--- a/src/commands/uploadFiles.ts
+++ b/src/commands/uploadFiles.ts
@@ -29,7 +29,6 @@ export async function uploadFiles(
 ): Promise<void> {
     let shouldCheckUris: boolean = false;
     if (uris === undefined) {
-        // tslint:disable: strict-boolean-expressions
         uris = await ext.ui.showOpenDialog(
             {
                 canSelectFiles: true,
@@ -45,6 +44,7 @@ export async function uploadFiles(
         shouldCheckUris = true;
     }
 
+    // tslint:disable-next-line: strict-boolean-expressions
     treeItem = treeItem || <BlobContainerTreeItem | FileShareTreeItem>(await ext.tree.showTreeItemPicker([BlobContainerTreeItem.contextValue, FileShareTreeItem.contextValue], context));
     let urisToUpload: Uri[] = [];
     if (shouldCheckUris) {

--- a/src/commands/uploadFolder.ts
+++ b/src/commands/uploadFolder.ts
@@ -3,25 +3,21 @@
  *  Licensed under the MIT License. See License.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { basename } from 'path';
 import * as vscode from 'vscode';
 import { IActionContext } from 'vscode-azureextensionui';
 import { NotificationProgress } from '../constants';
 import { ext } from '../extensionVariables';
 import { BlobContainerTreeItem } from '../tree/blob/BlobContainerTreeItem';
 import { FileShareTreeItem } from '../tree/fileShare/FileShareTreeItem';
-import { getBlobPath } from '../utils/blobUtils';
-import { getFileName } from '../utils/fileUtils';
-import { localize } from '../utils/localize';
-import { getUploadingMessageWithSource, showUploadWarning, upload, uploadLocalFolder } from '../utils/uploadUtils';
+import { getRemoteResourceName, getUploadingMessageWithSource, upload, uploadLocalFolder } from '../utils/uploadUtils';
 
 export async function uploadFolder(
     actionContext: IActionContext,
     treeItem?: BlobContainerTreeItem | FileShareTreeItem,
     uri?: vscode.Uri,
+    destPath?: string,
     notificationProgress?: NotificationProgress,
     cancellationToken?: vscode.CancellationToken,
-    suppressPrompts?: boolean
 ): Promise<void> {
     // tslint:disable: strict-boolean-expressions
     uri = uri || (await ext.ui.showOpenDialog({
@@ -33,16 +29,8 @@ export async function uploadFolder(
     }))[0];
 
     treeItem = treeItem || <BlobContainerTreeItem | FileShareTreeItem>(await ext.tree.showTreeItemPicker([BlobContainerTreeItem.contextValue, FileShareTreeItem.contextValue], actionContext));
-    // tslint:enable: strict-boolean-expressions
-
+    destPath = destPath || await getRemoteResourceName(treeItem, uri, { choice: undefined });
     const sourcePath: string = uri.fsPath;
-    let destPath: string = basename(sourcePath);
-    if (!suppressPrompts) {
-        destPath = treeItem instanceof BlobContainerTreeItem ?
-            await getBlobPath(treeItem, destPath) :
-            await getFileName(treeItem, '', treeItem.shareName, destPath);
-        await showUploadWarning(localize('uploadingWillOverwrite', 'Uploading "{0}" will overwrite any existing resources with the same name.', sourcePath));
-    }
 
     if (notificationProgress && cancellationToken) {
         // AzCopy recognizes folders as a resource when uploading to file shares. So only set `countFoldersAsResources=true` in that case
@@ -51,7 +39,7 @@ export async function uploadFolder(
         const title: string = getUploadingMessageWithSource(sourcePath, treeItem.label);
         await vscode.window.withProgress({ cancellable: true, location: vscode.ProgressLocation.Notification, title }, async (newNotificationProgress, newCancellationToken) => {
             // tslint:disable-next-line:no-non-null-assertion
-            await uploadLocalFolder(actionContext, treeItem!, sourcePath, destPath, newNotificationProgress, newCancellationToken, destPath, treeItem instanceof FileShareTreeItem);
+            await uploadLocalFolder(actionContext, treeItem!, sourcePath, destPath!, newNotificationProgress, newCancellationToken, destPath, treeItem instanceof FileShareTreeItem);
         });
     }
 }

--- a/src/commands/uploadFolder.ts
+++ b/src/commands/uploadFolder.ts
@@ -21,7 +21,6 @@ export async function uploadFolder(
 ): Promise<void> {
     let shouldCheckUri: boolean = false;
     if (uri === undefined) {
-        // tslint:disable: strict-boolean-expressions
         uri = (await ext.ui.showOpenDialog({
             canSelectFiles: false,
             canSelectFolders: true,
@@ -32,6 +31,7 @@ export async function uploadFolder(
         shouldCheckUri = true;
     }
 
+    // tslint:disable-next-line: strict-boolean-expressions
     treeItem = treeItem || <BlobContainerTreeItem | FileShareTreeItem>(await ext.tree.showTreeItemPicker([BlobContainerTreeItem.contextValue, FileShareTreeItem.contextValue], actionContext));
 
     if (shouldCheckUri && !(await shouldUploadUri(treeItem, uri, { choice: undefined }))) {

--- a/src/commands/uploadFolder.ts
+++ b/src/commands/uploadFolder.ts
@@ -9,6 +9,7 @@ import { NotificationProgress } from '../constants';
 import { ext } from '../extensionVariables';
 import { BlobContainerTreeItem } from '../tree/blob/BlobContainerTreeItem';
 import { FileShareTreeItem } from '../tree/fileShare/FileShareTreeItem';
+import { nonNullValue } from '../utils/nonNull';
 import { getRemoteResourceName, getUploadingMessageWithSource, upload, uploadLocalFolder } from '../utils/uploadUtils';
 
 export async function uploadFolder(
@@ -38,8 +39,7 @@ export async function uploadFolder(
     } else {
         const title: string = getUploadingMessageWithSource(sourcePath, treeItem.label);
         await vscode.window.withProgress({ cancellable: true, location: vscode.ProgressLocation.Notification, title }, async (newNotificationProgress, newCancellationToken) => {
-            // tslint:disable-next-line:no-non-null-assertion
-            await uploadLocalFolder(actionContext, treeItem!, sourcePath, destPath!, newNotificationProgress, newCancellationToken, destPath, treeItem instanceof FileShareTreeItem);
+            await uploadLocalFolder(actionContext, nonNullValue(treeItem), sourcePath, nonNullValue(destPath), newNotificationProgress, newCancellationToken, destPath, treeItem instanceof FileShareTreeItem);
         });
     }
 }

--- a/src/commands/uploadFolder.ts
+++ b/src/commands/uploadFolder.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { basename } from 'path';
 import * as vscode from 'vscode';
 import { IActionContext } from 'vscode-azureextensionui';
 import { NotificationProgress } from '../constants';
@@ -11,7 +10,7 @@ import { ext } from '../extensionVariables';
 import { BlobContainerTreeItem } from '../tree/blob/BlobContainerTreeItem';
 import { FileShareTreeItem } from '../tree/fileShare/FileShareTreeItem';
 import { nonNullValue } from '../utils/nonNull';
-import { getUploadingMessageWithSource, shouldUploadUri, upload, uploadLocalFolder } from '../utils/uploadUtils';
+import { convertLocalPathToRemotePath, getUploadingMessageWithSource, shouldUploadUri, upload, uploadLocalFolder } from '../utils/uploadUtils';
 
 export async function uploadFolder(
     actionContext: IActionContext,
@@ -41,7 +40,7 @@ export async function uploadFolder(
     }
 
     const sourcePath: string = uri.fsPath;
-    const destPath: string = basename(sourcePath);
+    const destPath: string = convertLocalPathToRemotePath(sourcePath);
 
     if (notificationProgress && cancellationToken) {
         // AzCopy recognizes folders as a resource when uploading to file shares. So only set `countFoldersAsResources=true` in that case

--- a/src/commands/uploadToAzureStorage.ts
+++ b/src/commands/uploadToAzureStorage.ts
@@ -11,8 +11,7 @@ import { BlobContainerTreeItem } from '../tree/blob/BlobContainerTreeItem';
 import { FileShareTreeItem } from '../tree/fileShare/FileShareTreeItem';
 import { throwIfCanceled } from '../utils/errorUtils';
 import { localize } from '../utils/localize';
-import { nonNullValue } from '../utils/nonNull';
-import { getRemoteResourceName, getUploadingMessage, OverwriteChoice, RemoteResourceNameMap } from '../utils/uploadUtils';
+import { getUploadingMessage, OverwriteChoice, shouldUploadUri } from '../utils/uploadUtils';
 import { uploadFiles } from './uploadFiles';
 import { uploadFolder } from './uploadFolder';
 
@@ -20,21 +19,19 @@ export async function uploadToAzureStorage(actionContext: IActionContext, _first
     const treeItem: BlobContainerTreeItem | FileShareTreeItem = await ext.tree.showTreeItemPicker([BlobContainerTreeItem.contextValue, FileShareTreeItem.contextValue], actionContext);
     const folderUris: vscode.Uri[] = [];
     const fileUris: vscode.Uri[] = [];
-    const remoteResourceNameMap: RemoteResourceNameMap = new Map();
-    let overwriteChoice: OverwriteChoice = { choice: undefined };
-    let remoteResourcePath: string;
+    let overwriteChoice: { choice: OverwriteChoice | undefined } = { choice: undefined };
+
     for (const uri of uris) {
         if (uri.scheme === 'azurestorage') {
             throw new Error(localize('cannotUploadToAzureFromAzureResource', 'Cannot upload to Azure from an Azure resource.'));
         }
 
-        remoteResourcePath = await getRemoteResourceName(treeItem, uri, overwriteChoice);
-        remoteResourceNameMap.set(uri, remoteResourcePath);
-
-        if ((await stat(uri.fsPath)).isDirectory()) {
-            folderUris.push(uri);
-        } else {
-            fileUris.push(uri);
+        if (await shouldUploadUri(treeItem, uri, overwriteChoice)) {
+            if ((await stat(uri.fsPath)).isDirectory()) {
+                folderUris.push(uri);
+            } else {
+                fileUris.push(uri);
+            }
         }
     }
 
@@ -42,13 +39,13 @@ export async function uploadToAzureStorage(actionContext: IActionContext, _first
     await vscode.window.withProgress({ cancellable: true, location: vscode.ProgressLocation.Notification, title }, async (notificationProgress, cancellationToken) => {
         for (const folderUri of folderUris) {
             throwIfCanceled(cancellationToken, actionContext.telemetry.properties, 'uploadToAzureStorage');
-            await uploadFolder(actionContext, treeItem, folderUri, nonNullValue(remoteResourceNameMap.get(folderUri)), notificationProgress, cancellationToken);
+            await uploadFolder(actionContext, treeItem, folderUri, notificationProgress, cancellationToken);
         }
 
-        await uploadFiles(actionContext, treeItem, fileUris, remoteResourceNameMap, notificationProgress, cancellationToken);
+        await uploadFiles(actionContext, treeItem, fileUris, notificationProgress, cancellationToken);
     });
 
-    const success: string = localize('successfullyUploaded', 'Successfully uploaded to "{0}"', treeItem.label);
-    ext.outputChannel.appendLog(success);
-    vscode.window.showInformationMessage(success);
+    const complete: string = localize('uploadComplete', 'Upload to "{0}" is complete', treeItem.label);
+    ext.outputChannel.appendLog(complete);
+    vscode.window.showInformationMessage(complete);
 }

--- a/src/commands/uploadToAzureStorage.ts
+++ b/src/commands/uploadToAzureStorage.ts
@@ -11,6 +11,7 @@ import { BlobContainerTreeItem } from '../tree/blob/BlobContainerTreeItem';
 import { FileShareTreeItem } from '../tree/fileShare/FileShareTreeItem';
 import { throwIfCanceled } from '../utils/errorUtils';
 import { localize } from '../utils/localize';
+import { nonNullValue } from '../utils/nonNull';
 import { getRemoteResourceName, getUploadingMessage, OverwriteChoice, RemoteResourceNameMap } from '../utils/uploadUtils';
 import { uploadFiles } from './uploadFiles';
 import { uploadFolder } from './uploadFolder';
@@ -41,8 +42,7 @@ export async function uploadToAzureStorage(actionContext: IActionContext, _first
     await vscode.window.withProgress({ cancellable: true, location: vscode.ProgressLocation.Notification, title }, async (notificationProgress, cancellationToken) => {
         for (const folderUri of folderUris) {
             throwIfCanceled(cancellationToken, actionContext.telemetry.properties, 'uploadToAzureStorage');
-            // tslint:disable-next-line:no-non-null-assertion
-            await uploadFolder(actionContext, treeItem, folderUri, remoteResourceNameMap.get(folderUri)!, notificationProgress, cancellationToken);
+            await uploadFolder(actionContext, treeItem, folderUri, nonNullValue(remoteResourceNameMap.get(folderUri)), notificationProgress, cancellationToken);
         }
 
         await uploadFiles(actionContext, treeItem, fileUris, remoteResourceNameMap, notificationProgress, cancellationToken);

--- a/src/utils/blobUtils.ts
+++ b/src/utils/blobUtils.ts
@@ -94,12 +94,19 @@ export async function doesBlobDirectoryExist(treeItem: BlobContainerTreeItem | B
     }
 
     const containerClient: azureStorageBlob.ContainerClient = createBlobContainerClient(treeItem.root, treeItem.container.name);
+    const response: AsyncIterableIterator<azureStorageBlob.ContainerListBlobHierarchySegmentResponse> = containerClient.listBlobsByHierarchy(sep, { prefix: blobDirectoryName }).byPage({ maxPageSize: 1 });
 
-    // tslint:disable-next-line: await-promise
-    for await (let _ of containerClient.listBlobsByHierarchy(sep, { prefix: blobDirectoryName })) {
-        // Blobs exist under this directory so the directory exists
-        return true;
+    // tslint:disable-next-line: no-unsafe-any
+    let responseValue: azureStorageBlob.ListBlobsHierarchySegmentResponse | undefined = (await response.next()).value;
+    while (responseValue) {
+        if (responseValue.segment.blobItems.length || responseValue.segment.blobPrefixes?.length) {
+            return true;
+        }
+
+        // tslint:disable-next-line: no-unsafe-any
+        responseValue = (await response.next()).value;
     }
+
     return false;
 }
 

--- a/src/utils/blobUtils.ts
+++ b/src/utils/blobUtils.ts
@@ -96,15 +96,10 @@ export async function doesBlobDirectoryExist(treeItem: BlobContainerTreeItem | B
     const containerClient: azureStorageBlob.ContainerClient = createBlobContainerClient(treeItem.root, treeItem.container.name);
     const response: AsyncIterableIterator<azureStorageBlob.ContainerListBlobHierarchySegmentResponse> = containerClient.listBlobsByHierarchy(sep, { prefix: blobDirectoryName }).byPage({ maxPageSize: 1 });
 
-    // tslint:disable-next-line: no-unsafe-any
-    let responseValue: azureStorageBlob.ListBlobsHierarchySegmentResponse | undefined = (await response.next()).value;
-    while (responseValue) {
+    for await (const responseValue of response) {
         if (responseValue.segment.blobItems.length || responseValue.segment.blobPrefixes?.length) {
             return true;
         }
-
-        // tslint:disable-next-line: no-unsafe-any
-        responseValue = (await response.next()).value;
     }
 
     return false;

--- a/src/utils/blobUtils.ts
+++ b/src/utils/blobUtils.ts
@@ -94,12 +94,11 @@ export async function doesBlobDirectoryExist(treeItem: BlobContainerTreeItem | B
     }
 
     const containerClient: azureStorageBlob.ContainerClient = createBlobContainerClient(treeItem.root, treeItem.container.name);
-    const prefix: string | undefined = treeItem instanceof BlobDirectoryTreeItem ? treeItem.dirPath : undefined;
+
     // tslint:disable-next-line: await-promise
-    for await (const item of containerClient.listBlobsByHierarchy(sep, { prefix })) {
-        if (item.kind === "prefix" && item.name === blobDirectoryName) {
-            return true;
-        }
+    for await (let _ of containerClient.listBlobsByHierarchy(sep, { prefix: blobDirectoryName })) {
+        // Blobs exist under this directory so the directory exists
+        return true;
     }
     return false;
 }

--- a/src/utils/uploadUtils.ts
+++ b/src/utils/uploadUtils.ts
@@ -117,4 +117,3 @@ async function getNumResourcesInDirectory(directoryPath: string, countFolders?: 
     const resources: readdirp.EntryInfo[] = await readdirp.promise(directoryPath, options);
     return resources.length;
 }
-

--- a/src/utils/uploadUtils.ts
+++ b/src/utils/uploadUtils.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { FromToOption, ILocalLocation, IRemoteSasLocation } from '@azure-tools/azcopy-node';
+import { basename } from 'path';
 import * as readdirp from 'readdirp';
 import * as vscode from 'vscode';
 import { IActionContext } from "vscode-azureextensionui";
@@ -14,9 +15,24 @@ import { ext } from '../extensionVariables';
 import { TransferProgress } from '../TransferProgress';
 import { BlobContainerTreeItem } from '../tree/blob/BlobContainerTreeItem';
 import { FileShareTreeItem } from '../tree/fileShare/FileShareTreeItem';
+import { doesBlobDirectoryExist, doesBlobExist, getBlobPath } from './blobUtils';
+import { doesDirectoryExist } from './directoryUtils';
+import { doesFileExist, getFileName } from './fileUtils';
 import { localize } from './localize';
 
 export const upload: string = localize('upload', 'Upload');
+
+/**
+ * Tracks whether or not to overwrite resources wile uploading.
+ *
+ * Stored as an object to make use of pass by reference.
+ */
+export type OverwriteChoice = { choice: 'Yes to all' | 'Yes' | 'No to all' | 'No' | undefined };
+
+/**
+ * Map of local URI to that resource's path in Azure.
+ */
+export type RemoteResourceNameMap = Map<vscode.Uri, string>;
 
 export async function uploadLocalFolder(
     context: IActionContext,
@@ -45,8 +61,51 @@ export function getUploadingMessageWithSource(sourcePath: string, treeItemLabel:
     return localize('uploadingFromTo', 'Uploading from "{0}" to "{1}"', sourcePath, treeItemLabel);
 }
 
-export async function showUploadWarning(message: string): Promise<void> {
-    await ext.ui.showWarningMessage(message, { modal: true }, { title: upload });
+export async function showUploadWarning(treeItem: BlobContainerTreeItem | FileShareTreeItem, resourcePath: string): Promise<OverwriteChoice> {
+    let shouldWarn: boolean;
+    if (treeItem instanceof BlobContainerTreeItem) {
+        shouldWarn = await doesBlobExist(treeItem, resourcePath) || await doesBlobDirectoryExist(treeItem, resourcePath);
+    } else {
+        shouldWarn = await doesFileExist(resourcePath, treeItem, '', treeItem.shareName) || await doesDirectoryExist(treeItem, resourcePath, treeItem.shareName);
+    }
+
+    if (shouldWarn) {
+        const message: string = localize('resourceExists', 'A resource named "{0}" already exists. Do you want to overwrite it?', resourcePath);
+        const items = [
+            { title: 'Yes to all' },
+            { title: 'Yes' },
+            { title: 'No to all' },
+            { title: 'No' }
+        ];
+        return <OverwriteChoice>{ choice: (await ext.ui.showWarningMessage(message, { modal: true }, ...items)).title };
+    } else {
+        // This resource doesn't exist so "overwriting" is OK
+        return { choice: 'Yes' };
+    }
+}
+
+export async function getRemoteResourceName(treeItem: BlobContainerTreeItem | FileShareTreeItem, uri: vscode.Uri, overwriteChoice: OverwriteChoice): Promise<string> {
+    const localResourcePath: string = uri.fsPath;
+    const remoteResourceName: string = basename(localResourcePath);
+    if (overwriteChoice.choice !== 'Yes to all' && overwriteChoice.choice !== 'No to all') {
+        // Only prompt if the overwrite choice could change
+        overwriteChoice.choice = (await showUploadWarning(treeItem, remoteResourceName)).choice;
+    }
+
+    switch (overwriteChoice.choice) {
+        case 'No':
+        case 'No to all':
+            // Prompt for a new remote resource name instead of overwriting
+            return treeItem instanceof BlobContainerTreeItem ?
+                await getBlobPath(treeItem, remoteResourceName) :
+                await getFileName(treeItem, '', treeItem.shareName, remoteResourceName);
+
+        case 'Yes':
+        case 'Yes to all':
+        default:
+            // Use the default remote resource name
+            return remoteResourceName;
+    }
 }
 
 async function getNumResourcesInDirectory(directoryPath: string, countFolders?: boolean): Promise<number> {

--- a/src/utils/uploadUtils.ts
+++ b/src/utils/uploadUtils.ts
@@ -90,7 +90,7 @@ export async function shouldUploadUri(treeItem: BlobContainerTreeItem | FileShar
     }
 
     const localResourcePath: string = uri.fsPath;
-    const remoteResourceName: string = basename(localResourcePath);
+    const remoteResourceName: string = convertLocalPathToRemotePath(localResourcePath);
     overwriteChoice.choice = await showUploadWarning(treeItem, remoteResourceName);
 
     switch (overwriteChoice.choice) {
@@ -105,6 +105,10 @@ export async function shouldUploadUri(treeItem: BlobContainerTreeItem | FileShar
     }
 }
 
+export function convertLocalPathToRemotePath(localPath: string): string {
+    return basename(localPath);
+}
+
 async function getNumResourcesInDirectory(directoryPath: string, countFolders?: boolean): Promise<number> {
     const options: readdirp.ReaddirpOptions = {
         directoryFilter: ['!.git', '!.vscode'],
@@ -113,3 +117,4 @@ async function getNumResourcesInDirectory(directoryPath: string, countFolders?: 
     const resources: readdirp.EntryInfo[] = await readdirp.promise(directoryPath, options);
     return resources.length;
 }
+

--- a/src/utils/uploadUtils.ts
+++ b/src/utils/uploadUtils.ts
@@ -23,7 +23,7 @@ import { localize } from './localize';
 export const upload: string = localize('upload', 'Upload');
 
 /**
- * Tracks whether or not to overwrite resources wile uploading.
+ * Tracks whether or not to overwrite resources while uploading.
  *
  * Stored as an object to make use of pass by reference.
  */


### PR DESCRIPTION
This takes care of all the overwrite prompts before any transfers are made.

Fixes https://github.com/microsoft/vscode-azurestorage/issues/757