### PR TITLE
Support directory downloads

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
         "onCommand:azureStorage.uploadFiles",
         "onCommand:azureStorage.uploadFolder",
         "onCommand:azureStorage.deleteBlob",
-        "onCommand:azureStorage.downloadFile",
+        "onCommand:azureStorage.download",
         "onCommand:azureStorage.createFileShare",
         "onCommand:azureStorage.deleteFileShare",
         "onCommand:azureStorage.deleteStorageAccount",
@@ -225,7 +225,7 @@
                 "category": "Azure Storage"
             },
             {
-                "command": "azureStorage.downloadFile",
+                "command": "azureStorage.download",
                 "title": "Download...",
                 "category": "Azure Storage"
             },
@@ -509,8 +509,13 @@
                     "when": "view == azureStorage && viewItem == azureBlob"
                 },
                 {
-                    "command": "azureStorage.downloadFile",
+                    "command": "azureStorage.download",
                     "when": "view == azureStorage && viewItem == azureBlob",
+                    "group": "3_download"
+                },
+                {
+                    "command": "azureStorage.download",
+                    "when": "view == azureStorage && viewItem == azureBlobDirectory",
                     "group": "3_download"
                 },
                 {
@@ -587,7 +592,7 @@
                 },
                 {
                     "$comment": "========= azureFile =========",
-                    "command": "azureStorage.downloadFile",
+                    "command": "azureStorage.download",
                     "when": "view == azureStorage && viewItem == azureFile",
                     "group": "3_download"
                 },
@@ -606,6 +611,11 @@
                     "command": "azureStorage.createFile",
                     "when": "view == azureStorage && viewItem == azureFileShareDirectory",
                     "group": "2_create@1"
+                },
+                {
+                    "command": "azureStorage.download",
+                    "when": "view == azureStorage && viewItem == azureFileShareDirectory",
+                    "group": "3_download"
                 },
                 {
                     "command": "azureStorage.createSubdirectory",
@@ -709,7 +719,7 @@
                     "when": "never"
                 },
                 {
-                    "command": "azureStorage.downloadFile",
+                    "command": "azureStorage.download",
                     "when": "never"
                 },
                 {

--- a/src/TransferProgress.ts
+++ b/src/TransferProgress.ts
@@ -8,29 +8,32 @@ import { ext } from './extensionVariables';
 
 export class TransferProgress {
     private message: string = '';
-    private percentage: number = 0;
+    private percentage: number | undefined;
     private lastPercentage: number = 0;
     private lastUpdated: number = Date.now();
 
     constructor(
-        private readonly totalWork: number,
+        public totalWork?: number,
         private readonly messagePrefix?: string,
         private readonly updateTimerMs: number = 200
     ) { }
 
-    public reportToNotification(finishedWork: number, notificationProgress: NotificationProgress): void {
+    public reportToNotification(finishedWork: number, notificationProgress: NotificationProgress, totalWork?: number): void {
+        this.totalWork = this.totalWork || totalWork;
+
         // This function may be called very frequently. Calls made to notificationProgress.report too rapidly result in incremental
         // progress not displaying in the notification window. So debounce calls to notificationProgress.report
         if (this.lastUpdated + this.updateTimerMs < Date.now()) {
             this.preReport(finishedWork);
-            if (this.percentage !== this.lastPercentage) {
+            if (this.percentage && this.percentage !== this.lastPercentage) {
                 notificationProgress.report({ message: this.message, increment: this.percentage - this.lastPercentage });
             }
             this.postReport();
         }
     }
 
-    public reportToOutputWindow(finishedWork: number): void {
+    public reportToOutputWindow(finishedWork: number, totalWork?: number): void {
+        this.totalWork = this.totalWork || totalWork;
         this.preReport(finishedWork);
         if (this.percentage !== this.lastPercentage) {
             ext.outputChannel.appendLog(this.message);
@@ -39,13 +42,18 @@ export class TransferProgress {
     }
 
     private preReport(finishedWork: number): void {
-        this.percentage = Math.trunc((finishedWork / this.totalWork) * 100);
+        if (this.totalWork) {
+            this.percentage = Math.trunc((finishedWork / this.totalWork) * 100);
+        }
         const prefix: string = this.messagePrefix ? `${this.messagePrefix}: ` : '';
-        this.message = `${prefix}${finishedWork}/${this.totalWork} (${this.percentage}%)`;
+        // tslint:disable-next-line: strict-boolean-expressions
+        this.message = `${prefix}${finishedWork}/${this.totalWork || '?'} (${this.percentage || '?'}%)`;
     }
 
     private postReport(): void {
-        this.lastPercentage = this.percentage;
+        if (this.percentage) {
+            this.lastPercentage = this.percentage;
+        }
         this.lastUpdated = Date.now();
     }
 }

--- a/src/TransferProgress.ts
+++ b/src/TransferProgress.ts
@@ -8,7 +8,7 @@ import { ext } from './extensionVariables';
 
 export class TransferProgress {
     private message: string = '';
-    private percentage: number | undefined;
+    private percentage: number = 0;
     private lastPercentage: number = 0;
     private lastUpdated: number = Date.now();
 
@@ -25,7 +25,7 @@ export class TransferProgress {
         // progress not displaying in the notification window. So debounce calls to notificationProgress.report
         if (this.lastUpdated + this.updateTimerMs < Date.now()) {
             this.preReport(finishedWork);
-            if (this.percentage && this.percentage !== this.lastPercentage) {
+            if (this.percentage !== this.lastPercentage) {
                 notificationProgress.report({ message: this.message, increment: this.percentage - this.lastPercentage });
             }
             this.postReport();
@@ -43,17 +43,15 @@ export class TransferProgress {
 
     private preReport(finishedWork: number): void {
         if (this.totalWork) {
+            // Only update message if `totalWork` is valid
             this.percentage = Math.trunc((finishedWork / this.totalWork) * 100);
+            const prefix: string = this.messagePrefix ? `${this.messagePrefix}: ` : '';
+            this.message = `${prefix}${finishedWork}/${this.totalWork} (${this.percentage}%)`;
         }
-        const prefix: string = this.messagePrefix ? `${this.messagePrefix}: ` : '';
-        // tslint:disable-next-line: strict-boolean-expressions
-        this.message = `${prefix}${finishedWork}/${this.totalWork || '?'} (${this.percentage || '?'}%)`;
     }
 
     private postReport(): void {
-        if (this.percentage) {
-            this.lastPercentage = this.percentage;
-        }
+        this.lastPercentage = this.percentage;
         this.lastUpdated = Date.now();
     }
 }

--- a/src/commands/azCopy/azCopyTransfer.ts
+++ b/src/commands/azCopy/azCopyTransfer.ts
@@ -80,9 +80,15 @@ async function startAndWaitForCopy(
         status = (await copyClient.getJobInfo(jobId)).latestStatus;
 
         // Directory transfers always have `useWildCard` set
-        // tslint:disable-next-line: strict-boolean-expressions
+        // tslint:disable: strict-boolean-expressions
         finishedWork = (src.useWildCard ? status?.TransfersCompleted : status?.BytesOverWire) || 0;
-        transferProgress.reportToOutputWindow(finishedWork);
+
+        let totalWork: number | undefined;
+        if (!transferProgress.totalWork) {
+            totalWork = (src.useWildCard ? status?.TotalTransfers : status?.TotalBytesEnumerated) || undefined;
+            // tslint:enable: strict-boolean-expressions
+        }
+        transferProgress.reportToOutputWindow(finishedWork, totalWork);
         if (!!notificationProgress) {
             transferProgress.reportToNotification(finishedWork, notificationProgress);
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,7 +16,7 @@ import { registerBlobContainerActionHandlers } from './commands/blob/blobContain
 import { registerBlobContainerGroupActionHandlers } from './commands/blob/blobContainerGroupActionHandlers';
 import { createStorageAccount, createStorageAccountAdvanced } from './commands/createStorageAccount';
 import { detachStorageAccount } from './commands/detachStorageAccount';
-import { downloadFile } from './commands/downloadFile';
+import { download } from './commands/downloadFile';
 import { registerDirectoryActionHandlers } from './commands/fileShare/directoryActionHandlers';
 import { registerFileActionHandlers } from './commands/fileShare/fileActionHandlers';
 import { registerFileShareActionHandlers } from './commands/fileShare/fileShareActionHandlers';
@@ -140,7 +140,7 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
     registerCommand("azureStorage.uploadFiles", uploadFiles);
     registerCommand("azureStorage.uploadFolder", uploadFolder);
     registerCommand("azureStorage.uploadToAzureStorage", uploadToAzureStorage);
-    registerCommand('azureStorage.downloadFile', downloadFile);
+    registerCommand('azureStorage.download', download);
     registerCommand("azureStorage.attachStorageAccount", async () => {
         await ext.attachedStorageAccountsTreeItem.attachWithConnectionString();
     });


### PR DESCRIPTION
There wasn't a good way to get how many children a blob directory or file directory has. So I modified `TransferProgress` to not take `totalWork` as a required parameter. Instead, AzCopy gives us that info during the transfer. Directory downloads will display a "?" for the initial total work and percentage until AzCopy reports that info (it takes about a second before that happens).

<img width="424" alt="Screen Shot 2020-09-10 at 4 08 58 PM" src="https://user-images.githubusercontent.com/22795803/92823194-dbab7880-f381-11ea-9b6e-3c74cd6b45e9.png">


Fixes https://github.com/microsoft/vscode-azurestorage/issues/756