### PR TITLE
Automatically show folders in Azure tree view after upload

### DIFF
--- a/src/commands/uploadFolder.ts
+++ b/src/commands/uploadFolder.ts
@@ -51,4 +51,6 @@ export async function uploadFolder(
             await uploadLocalFolder(actionContext, nonNullValue(treeItem), sourcePath, nonNullValue(destPath), newNotificationProgress, newCancellationToken, destPath, treeItem instanceof FileShareTreeItem);
         });
     }
+
+    await ext.tree.refresh(treeItem);
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurestorage/issues/804