### PR TITLE
Continue AzCopy upload after an error occurs

### DIFF
--- a/src/commands/azCopy/IAzCopyResolution.ts
+++ b/src/commands/azCopy/IAzCopyResolution.ts
@@ -1,0 +1,10 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IParsedError } from "vscode-azureextensionui";
+
+export interface IAzCopyResolution {
+    errors: IParsedError[];
+}

--- a/src/commands/azCopy/azCopyTransfer.ts
+++ b/src/commands/azCopy/azCopyTransfer.ts
@@ -33,7 +33,7 @@ export async function azCopyTransfer(
         // tslint:disable-next-line: strict-boolean-expressions
         let message: string = localize('azCopyTransfer', 'AzCopy Transfer: "{0}".', finalTransferStatus?.JobStatus || 'Failed');
         if (finalTransferStatus?.FailedTransfers?.length || finalTransferStatus?.SkippedTransfers?.length) {
-            message += localize('checkOutputWindow', ' Check the output window for a list of incomplete transfers.');
+            message += localize('checkOutputWindow', ' Check the [output window](command:{0}) for a list of incomplete transfers.', `${ext.prefix}.showOutputChannel`);
 
             if (finalTransferStatus.FailedTransfers?.length) {
                 ext.outputChannel.appendLog(localize('failedTransfers', 'Failed transfer(s):'));

--- a/src/commands/azCopy/azCopyTransfer.ts
+++ b/src/commands/azCopy/azCopyTransfer.ts
@@ -35,18 +35,14 @@ export async function azCopyTransfer(
         if (finalTransferStatus?.FailedTransfers?.length || finalTransferStatus?.SkippedTransfers?.length) {
             message += localize('checkOutputWindow', ' Check the output window for a list of incomplete transfers.');
 
-            // The optional "s" at the end of "transfer(s)"
-            let s: string;
             if (finalTransferStatus.FailedTransfers?.length) {
-                s = finalTransferStatus.FailedTransfers.length > 1 ? 's' : '';
-                ext.outputChannel.appendLog(localize('failedTransfers', 'Failed transfer{0}:', s));
+                ext.outputChannel.appendLog(localize('failedTransfers', 'Failed transfer(s):'));
                 for (let failedTransfer of finalTransferStatus.FailedTransfers) {
                     ext.outputChannel.appendLog(`\t${failedTransfer.Dst}`);
                 }
             }
             if (finalTransferStatus.SkippedTransfers?.length) {
-                s = finalTransferStatus.SkippedTransfers.length > 1 ? 's' : '';
-                ext.outputChannel.appendLog(localize('skippedTransfers', 'Skipped transfer{0}:', s));
+                ext.outputChannel.appendLog(localize('skippedTransfers', 'Skipped transfer(s):'));
                 for (let skippedTransfer of finalTransferStatus.SkippedTransfers) {
                     ext.outputChannel.appendLog(`\t${skippedTransfer.Dst}`);
                 }

--- a/src/commands/azCopy/azCopyTransfer.ts
+++ b/src/commands/azCopy/azCopyTransfer.ts
@@ -35,14 +35,18 @@ export async function azCopyTransfer(
         if (finalTransferStatus?.FailedTransfers?.length || finalTransferStatus?.SkippedTransfers?.length) {
             message += localize('checkOutputWindow', ' Check the output window for a list of incomplete transfers.');
 
+            // The optional "s" at the end of "transfer(s)"
+            let s: string;
             if (finalTransferStatus.FailedTransfers?.length) {
-                ext.outputChannel.appendLog(localize('failedTransfers', 'Failed transfers:'));
+                s = finalTransferStatus.FailedTransfers.length > 1 ? 's' : '';
+                ext.outputChannel.appendLog(localize('failedTransfers', 'Failed transfer{0}:', s));
                 for (let failedTransfer of finalTransferStatus.FailedTransfers) {
                     ext.outputChannel.appendLog(`\t${failedTransfer.Dst}`);
                 }
             }
             if (finalTransferStatus.SkippedTransfers?.length) {
-                ext.outputChannel.appendLog(localize('skippedTransfers', 'Skipped transfers:'));
+                s = finalTransferStatus.SkippedTransfers.length > 1 ? 's' : '';
+                ext.outputChannel.appendLog(localize('skippedTransfers', 'Skipped transfer{0}:', s));
                 for (let skippedTransfer of finalTransferStatus.SkippedTransfers) {
                     ext.outputChannel.appendLog(`\t${skippedTransfer.Dst}`);
                 }

--- a/src/commands/uploadFiles.ts
+++ b/src/commands/uploadFiles.ts
@@ -29,7 +29,6 @@ export async function uploadFiles(
     cancellationToken?: CancellationToken,
     destinationDirectory?: string
 ): Promise<IParsedError[]> {
-    const calledFromUploadToAzureStorage: boolean = uris !== undefined;
     if (uris === undefined) {
         uris = await ext.ui.showOpenDialog(
             {
@@ -49,6 +48,7 @@ export async function uploadFiles(
     treeItem = treeItem || <BlobContainerTreeItem | FileShareTreeItem>(await ext.tree.showTreeItemPicker([BlobContainerTreeItem.contextValue, FileShareTreeItem.contextValue], context));
     destinationDirectory = await getDestinationDirectory(destinationDirectory);
     let urisToUpload: Uri[] = [];
+    const calledFromUploadToAzureStorage: boolean = uris !== undefined;
     if (!calledFromUploadToAzureStorage) {
         let overwriteChoice: { choice: OverwriteChoice | undefined } = { choice: undefined };
         for (const uri of uris) {

--- a/src/commands/uploadFolder.ts
+++ b/src/commands/uploadFolder.ts
@@ -21,7 +21,6 @@ export async function uploadFolder(
     cancellationToken?: vscode.CancellationToken,
     destinationDirectory?: string
 ): Promise<IParsedError[]> {
-    const calledFromUploadToAzureStorage: boolean = uri !== undefined;
     if (uri === undefined) {
         uri = (await ext.ui.showOpenDialog({
             canSelectFiles: false,
@@ -36,6 +35,7 @@ export async function uploadFolder(
     treeItem = treeItem || <BlobContainerTreeItem | FileShareTreeItem>(await ext.tree.showTreeItemPicker([BlobContainerTreeItem.contextValue, FileShareTreeItem.contextValue], actionContext));
     destinationDirectory = await getDestinationDirectory(destinationDirectory);
 
+    const calledFromUploadToAzureStorage: boolean = uri !== undefined;
     if (!calledFromUploadToAzureStorage && !(await shouldUploadUri(treeItem, uri, { choice: undefined }, destinationDirectory))) {
         // Don't upload this folder
         return [];

--- a/src/commands/uploadToAzureStorage.ts
+++ b/src/commands/uploadToAzureStorage.ts
@@ -66,10 +66,10 @@ export async function uploadToAzureStorage(actionContext: IActionContext, _first
     await vscode.window.withProgress({ cancellable: true, location: vscode.ProgressLocation.Notification, title }, async (notificationProgress, cancellationToken) => {
         for (const folderUri of folderUris) {
             throwIfCanceled(cancellationToken, actionContext.telemetry.properties, 'uploadToAzureStorage');
-            errors.push(...(await uploadFolder(actionContext, treeItem, folderUri, notificationProgress, cancellationToken, destinationDirectory)));
+            errors.push(...(await uploadFolder(actionContext, treeItem, folderUri, notificationProgress, cancellationToken, destinationDirectory)).errors);
         }
 
-        errors.push(...(await uploadFiles(actionContext, treeItem, fileUris, notificationProgress, cancellationToken, destinationDirectory)));
+        errors.push(...(await uploadFiles(actionContext, treeItem, fileUris, notificationProgress, cancellationToken, destinationDirectory)).errors);
     });
 
     if (errors.length === 1) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -77,6 +77,7 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
         context.subscriptions.push(vscode.workspace.registerFileSystemProvider('azurestorage', ext.azureStorageFS, { isCaseSensitive: true }));
         context.subscriptions.push(vscode.workspace.registerTextDocumentContentProvider('azurestorage', ext.azureStorageFS));
 
+        registerCommand('azureStorage.showOutputChannel', () => { ext.outputChannel.show(); });
         registerCommand('azureStorage.openInFileExplorer', async (actionContext: IActionContext, treeItem?: BlobContainerTreeItem | FileShareTreeItem) => {
             if (!treeItem) {
                 treeItem = <BlobContainerTreeItem | FileShareTreeItem>(await ext.tree.showTreeItemPicker([BlobContainerTreeItem.contextValue, FileShareTreeItem.contextValue], actionContext));

--- a/src/utils/errorUtils.ts
+++ b/src/utils/errorUtils.ts
@@ -5,9 +5,10 @@
 
 import * as vscode from 'vscode';
 import { IParsedError, TelemetryProperties, UserCancelledError } from 'vscode-azureextensionui';
+import { ext } from '../extensionVariables';
 import { localize } from './localize';
 
-export const multipleAzCopyErrorsMessage: string = localize('multipleAzCopyErrors', 'Multiple AzCopy errors occurred while uploading. Check the output window for more details.');
+export const multipleAzCopyErrorsMessage: string = localize('multipleAzCopyErrors', 'Multiple AzCopy errors occurred while uploading. Check the [output window](command:{0}) for more details.', `${ext.prefix}.showOutputChannel`);
 
 export function throwIfCanceled(cancellationToken: vscode.CancellationToken | undefined, properties: TelemetryProperties | undefined, cancelStep: string): void {
     if (cancellationToken && cancellationToken.isCancellationRequested) {

--- a/src/utils/errorUtils.ts
+++ b/src/utils/errorUtils.ts
@@ -4,7 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import { TelemetryProperties, UserCancelledError } from 'vscode-azureextensionui';
+import { IParsedError, TelemetryProperties, UserCancelledError } from 'vscode-azureextensionui';
+import { localize } from './localize';
+
+export const multipleAzCopyErrorsMessage: string = localize('multipleAzCopyErrors', 'Multiple AzCopy errors occurred while uploading. Check the output window for more details.');
 
 export function throwIfCanceled(cancellationToken: vscode.CancellationToken | undefined, properties: TelemetryProperties | undefined, cancelStep: string): void {
     if (cancellationToken && cancellationToken.isCancellationRequested) {
@@ -13,4 +16,8 @@ export function throwIfCanceled(cancellationToken: vscode.CancellationToken | un
         }
         throw new UserCancelledError();
     }
+}
+
+export function isAzCopyError(parsedError: IParsedError): boolean {
+    return /azcopy/i.test(parsedError.message);
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurestorage/issues/817

Here's a few examples of what this looks like in action:

#### Multiple failures while uploading
<img width="679" alt="Screen Shot 2020-09-22 at 4 09 01 PM" src="https://user-images.githubusercontent.com/22795803/93946582-7a26ca80-fcee-11ea-95b6-3a7fef4d9ab1.png">

#### A single failure while uploading
<img width="679" alt="Screen Shot 2020-09-22 at 4 09 41 PM" src="https://user-images.githubusercontent.com/22795803/93946591-7dba5180-fcee-11ea-874d-0ec8309ba13a.png">
