### PR TITLE
Display 'only GPV2 accounts support hosting' error when disabling site for GPV1 account

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -123,7 +123,7 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
                     mustBeWebsiteCapable: false,
                     configureWebsite: false
                 });
-            await accountTreeItem.disableStaticWebsite();
+            await accountTreeItem.disableStaticWebsite(actionContext);
         });
         registerCommand("azureStorage.createGpv2Account", createStorageAccount);
         registerCommand("azureStorage.createGpv2AccountAdvanced", createStorageAccountAdvanced);

--- a/src/tree/StorageAccountTreeItem.ts
+++ b/src/tree/StorageAccountTreeItem.ts
@@ -273,8 +273,10 @@ export class StorageAccountTreeItem extends AzureParentTreeItem<IStorageRoot> {
         await wizard.execute();
     }
 
-    public async disableStaticWebsite(): Promise<void> {
+    public async disableStaticWebsite(context: IActionContext): Promise<void> {
         let websiteHostingStatus = await this.getActualWebsiteHostingStatus();
+        await this.ensureHostingCapable(context, websiteHostingStatus);
+
         if (!websiteHostingStatus.enabled) {
             window.showInformationMessage(`Account '${this.label}' does not currently have static website hosting enabled.`);
             return;


### PR DESCRIPTION
Now these static site commands all display the same error for GPV1 accounts:

<img width="440" alt="Screen Shot 2020-10-05 at 1 26 14 PM" src="https://user-images.githubusercontent.com/22795803/95129281-aa6b6180-070f-11eb-829f-94cf655d9a75.png">

<img width="386" alt="Screen Shot 2020-10-05 at 1 27 35 PM" src="https://user-images.githubusercontent.com/22795803/95129289-ae977f00-070f-11eb-89d3-ba57a7726974.png">

Fixes https://github.com/microsoft/vscode-azurestorage/issues/301

