### PR TITLE
Refresh directory tree item when refreshing the file explorer

### DIFF
--- a/src/AzureStorageFS.ts
+++ b/src/AzureStorageFS.ts
@@ -102,6 +102,9 @@ export class AzureStorageFS implements vscode.FileSystemProvider, vscode.TextDoc
             context.telemetry.suppressIfSuccessful = true;
             let treeItem: AzureStorageDirectoryTreeItem = await this.lookupAsDirectory(uri, context);
 
+            // https://github.com/microsoft/vscode-azurestorage/issues/712
+            await treeItem.refresh();
+
             const loadingMessage: string = localize('loadingDir', 'Loading directory "{0}"...', treeItem.label);
             let children: AzExtTreeItem[] = await treeItem.loadAllChildren({ ...context, loadingMessage });
             let result: [string, vscode.FileType][] = [];

--- a/src/AzureStorageFS.ts
+++ b/src/AzureStorageFS.ts
@@ -101,8 +101,6 @@ export class AzureStorageFS implements vscode.FileSystemProvider, vscode.TextDoc
         return await callWithTelemetryAndErrorHandling('readDirectory', async (context) => {
             context.telemetry.suppressIfSuccessful = true;
             let treeItem: AzureStorageDirectoryTreeItem = await this.lookupAsDirectory(uri, context);
-
-            // https://github.com/microsoft/vscode-azurestorage/issues/712
             await treeItem.refresh();
 
             const loadingMessage: string = localize('loadingDir', 'Loading directory "{0}"...', treeItem.label);


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurestorage/issues/712

When you open the file explorer in a new window and create a blob in a different window, that blob won't show up in the file explorer because we weren't refreshing the tree item. We were just loading what children existed when the file explorer was opened. So a refresh before calling `treeItem.loadAllChildren` fixes it