### PR TITLE
Revert "Refresh directory tree item when refreshing the file explorer"

### DIFF
--- a/src/AzureStorageFS.ts
+++ b/src/AzureStorageFS.ts
@@ -101,7 +101,6 @@ export class AzureStorageFS implements vscode.FileSystemProvider, vscode.TextDoc
         return await callWithTelemetryAndErrorHandling('readDirectory', async (context) => {
             context.telemetry.suppressIfSuccessful = true;
             let treeItem: AzureStorageDirectoryTreeItem = await this.lookupAsDirectory(uri, context);
-            await treeItem.refresh();
 
             const loadingMessage: string = localize('loadingDir', 'Loading directory "{0}"...', treeItem.label);
             let children: AzExtTreeItem[] = await treeItem.loadAllChildren({ ...context, loadingMessage });


### PR DESCRIPTION
Reverts microsoft/vscode-azurestorage#840 since spending more time to fix https://github.com/microsoft/vscode-azurestorage/issues/712 doesn't seem worth it 