### PR TITLE
Add missing AzCopy error message

### DIFF
--- a/src/commands/azCopy/azCopyTransfer.ts
+++ b/src/commands/azCopy/azCopyTransfer.ts
@@ -43,7 +43,7 @@ async function handleJob(context: IActionContext, jobInfo: IJobInfo, transferLab
     context.telemetry.properties.jobStatus = finalTransferStatus?.JobStatus;
     if (!finalTransferStatus || finalTransferStatus.JobStatus !== 'Completed') {
         // tslint:disable-next-line: strict-boolean-expressions
-        let message: string = localize('azCopyTransfer', 'AzCopy Transfer: "{0}".', finalTransferStatus?.JobStatus || 'Failed');
+        let message: string = jobInfo.errorMessage || localize('azCopyTransfer', 'AzCopy Transfer: "{0}". ', finalTransferStatus?.JobStatus || 'Failed');
         if (finalTransferStatus?.FailedTransfers?.length || finalTransferStatus?.SkippedTransfers?.length) {
             message += localize('checkOutputWindow', ' Check the [output window](command:{0}) for a list of incomplete transfers.', `${ext.prefix}.showOutputChannel`);
 
@@ -59,7 +59,7 @@ async function handleJob(context: IActionContext, jobInfo: IJobInfo, transferLab
                     ext.outputChannel.appendLog(`\t${skippedTransfer.Dst}`);
                 }
             }
-        } else {
+        } else if (!jobInfo.errorMessage) {
             // Add an additional error log since we don't have any more info about the failure
             ext.outputChannel.appendLog(localize('couldNotTransfer', 'Could not transfer "{0}"', transferLabel));
         }

--- a/src/commands/azCopy/azCopyTransfer.ts
+++ b/src/commands/azCopy/azCopyTransfer.ts
@@ -59,7 +59,7 @@ async function handleJob(context: IActionContext, jobInfo: IJobInfo, transferLab
                     ext.outputChannel.appendLog(`\t${skippedTransfer.Dst}`);
                 }
             }
-        } else if (!jobInfo.errorMessage) {
+        } else {
             // Add an additional error log since we don't have any more info about the failure
             ext.outputChannel.appendLog(localize('couldNotTransfer', 'Could not transfer "{0}"', transferLabel));
         }


### PR DESCRIPTION
I'm not sure how I originally missed this but I did...

Here's an example error message:
<img width="562" alt="Screen Shot 2020-11-09 at 4 35 13 PM" src="https://user-images.githubusercontent.com/22795803/98612744-a2bc5100-22a9-11eb-9b98-eeda19c6bb86.png">
