### PR TITLE
Lazy load azure storage package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1234,6 +1234,14 @@
             "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
             "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
         },
+        "axios": {
+            "version": "0.19.2",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+            "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+            "requires": {
+                "follow-redirects": "1.5.10"
+            }
+        },
         "azure-devops-node-api": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-7.2.0.tgz",
@@ -3800,6 +3808,24 @@
                     "dev": true,
                     "requires": {
                         "safe-buffer": "~5.1.0"
+                    }
+                }
+            }
+        },
+        "follow-redirects": {
+            "version": "1.5.10",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+            "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+            "requires": {
+                "debug": "=3.1.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "requires": {
+                        "ms": "2.0.0"
                     }
                 }
             }
@@ -6453,8 +6479,7 @@
         "ms": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-            "dev": true
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
         "mute-stdout": {
             "version": "1.0.1",
@@ -8429,6 +8454,14 @@
                 }
             }
         },
+        "tas-client": {
+            "version": "0.1.11",
+            "resolved": "https://registry.npmjs.org/tas-client/-/tas-client-0.1.11.tgz",
+            "integrity": "sha512-cvGzJO+A4GAgfXf1SUDw65WvSj7sMs1kqv5CaI4kjTEEh91NDepoMBA0+CrQYsMnXHAQA31MmVveARFcfXGSLg==",
+            "requires": {
+                "axios": "^0.19.0"
+            }
+        },
         "terser": {
             "version": "4.8.0",
             "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
@@ -9313,9 +9346,9 @@
             }
         },
         "vscode-azureextensionui": {
-            "version": "0.34.0",
-            "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.34.0.tgz",
-            "integrity": "sha512-m2JTdVYFNtuS3p25TiFpUzfKG/VMqcOGcwiLzpyadhN3GGB4o25sQG4r2Vw93vRqNj8ZrKsQqD9swU3L2FDkkQ==",
+            "version": "0.36.1",
+            "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.36.1.tgz",
+            "integrity": "sha512-XNMjCvB0/xa9ZZ2kTjiAOtpc2p4A/1b20HwHGCeB6pZisHO6mqRKCybiVE5Z/5XpRKc7NmLhJKr7ByLljlFxxg==",
             "requires": {
                 "@azure/arm-resources": "^3.0.0",
                 "@azure/arm-storage": "^15.0.0",
@@ -9329,7 +9362,8 @@
                 "opn": "^6.0.0",
                 "semver": "^5.7.1",
                 "vscode-extension-telemetry": "^0.1.5",
-                "vscode-nls": "^4.1.1"
+                "vscode-nls": "^4.1.1",
+                "vscode-tas-client": "^0.1.13"
             },
             "dependencies": {
                 "opn": {
@@ -9354,6 +9388,14 @@
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-4.1.2.tgz",
             "integrity": "sha512-7bOHxPsfyuCqmP+hZXscLhiHwe7CSuFE4hyhbs22xPIhQ4jv99FcR4eBzfYYVLP356HNFpdvz63FFb/xw6T4Iw=="
+        },
+        "vscode-tas-client": {
+            "version": "0.1.15",
+            "resolved": "https://registry.npmjs.org/vscode-tas-client/-/vscode-tas-client-0.1.15.tgz",
+            "integrity": "sha512-PFm+66FWwxK/ku4VvhvL/t3LGu4TKBing7KN/JF3XZbyJTNd3XQCCBu46b5MinysyzTWZap3s7xwAn5lGJQf5g==",
+            "requires": {
+                "tas-client": "0.1.11"
+            }
         },
         "vscode-test": {
             "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -854,6 +854,7 @@
         "@types/p-retry": "^3.0.1",
         "@types/vscode": "1.48.0",
         "@types/winreg": "1.2.30",
+        "@azure/arm-resources": "^3.0.0",
         "copy-webpack-plugin": "^5.1.2",
         "gulp": "^4.0.0",
         "mocha": "^7.1.1",
@@ -871,7 +872,6 @@
     },
     "dependencies": {
         "@azure-tools/azcopy-node": "1.0.0",
-        "@azure/arm-resources": "^3.0.0",
         "@azure/arm-storage": "^15.0.0",
         "@azure/storage-blob": "^12.1.1",
         "@azure/storage-file-share": "^12.1.1",
@@ -883,7 +883,7 @@
         "opn": "^5.3.0",
         "p-retry": "^4.2.0",
         "readdirp": "^3.4.0",
-        "vscode-azureextensionui": "^0.34.0",
+        "vscode-azureextensionui": "^0.36.1",
         "vscode-nls": "^4.1.1",
         "winreg": "^1.2.3"
     },

--- a/src/tree/StorageAccountTreeItem.ts
+++ b/src/tree/StorageAccountTreeItem.ts
@@ -11,9 +11,10 @@ import * as azureStorage from "azure-storage";
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { commands, MessageItem, Uri, window } from 'vscode';
-import { AzureParentTreeItem, AzureTreeItem, AzureWizard, createAzureClient, DialogResponses, IActionContext, ISubscriptionContext, UserCancelledError } from 'vscode-azureextensionui';
+import { AzureParentTreeItem, AzureTreeItem, AzureWizard, DialogResponses, IActionContext, ISubscriptionContext, UserCancelledError } from 'vscode-azureextensionui';
 import { getResourcesPath, staticWebsiteContainerName } from '../constants';
 import { ext } from "../extensionVariables";
+import { createStorageClient } from '../utils/azureClients';
 import { localize } from '../utils/localize';
 import { nonNullProp } from '../utils/nonNull';
 import { openUrl } from '../utils/openUrl';
@@ -127,7 +128,7 @@ export class StorageAccountTreeItem extends AzureParentTreeItem<IStorageRoot> {
         const result = await ext.ui.showWarningMessage(message, { modal: true }, DialogResponses.deleteResponse, DialogResponses.cancel);
         if (result === DialogResponses.deleteResponse) {
             const deletingStorageAccount: string = localize('deletingStorageAccount', 'Deleting storage account "{0}"...', this.label);
-            let storageManagementClient = createAzureClient(this.root, StorageManagementClient);
+            let storageManagementClient = await createStorageClient(this.root);
             let parsedId = this.parseAzureResourceId(this.storageAccount.id);
             let resourceGroupName = parsedId.resourceGroups;
 

--- a/src/tree/SubscriptionTreeItem.ts
+++ b/src/tree/SubscriptionTreeItem.ts
@@ -3,10 +3,10 @@
  *  Licensed under the MIT License. See License.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { StorageManagementClient } from '@azure/arm-storage';
 import * as vscode from 'vscode';
-import { AzExtTreeItem, AzureTreeItem, AzureWizard, AzureWizardExecuteStep, AzureWizardPromptStep, createAzureClient, ICreateChildImplContext, IStorageAccountWizardContext, LocationListStep, ResourceGroupCreateStep, ResourceGroupListStep, StorageAccountKind, StorageAccountPerformance, StorageAccountReplication, SubscriptionTreeItemBase, VerifyProvidersStep } from 'vscode-azureextensionui';
+import { AzExtTreeItem, AzureTreeItem, AzureWizard, AzureWizardExecuteStep, AzureWizardPromptStep, ICreateChildImplContext, IStorageAccountWizardContext, LocationListStep, ResourceGroupCreateStep, ResourceGroupListStep, StorageAccountKind, StorageAccountPerformance, StorageAccountReplication, SubscriptionTreeItemBase, VerifyProvidersStep } from 'vscode-azureextensionui';
 import { ISelectStorageAccountContext } from '../commands/selectStorageAccountNodeForCommand';
+import { createStorageClient } from '../utils/azureClients';
 import { nonNull, StorageAccountWrapper } from '../utils/storageWrappers';
 import { AttachedStorageAccountTreeItem } from './AttachedStorageAccountTreeItem';
 import { StaticWebsiteConfigureStep } from './createWizard/StaticWebsiteConfigureStep';
@@ -23,7 +23,7 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
     public supportsAdvancedCreation: boolean = true;
 
     async loadMoreChildrenImpl(_clearCache: boolean): Promise<AzExtTreeItem[]> {
-        let storageManagementClient = createAzureClient(this.root, StorageManagementClient);
+        let storageManagementClient = await createStorageClient(this.root);
         let accounts = await storageManagementClient.storageAccounts.list();
         return this.createTreeItemsWithErrorHandling(
             accounts,

--- a/src/tree/createWizard/StorageAccountTreeItemCreateStep.ts
+++ b/src/tree/createWizard/StorageAccountTreeItemCreateStep.ts
@@ -3,8 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { StorageManagementClient } from '@azure/arm-storage';
-import { AzureWizardExecuteStep, createAzureClient, IStorageAccountWizardContext } from "vscode-azureextensionui";
+import { AzureWizardExecuteStep, IStorageAccountWizardContext } from "vscode-azureextensionui";
+import { createStorageClient } from "../../utils/azureClients";
 import { nonNullProp } from '../../utils/nonNull';
 import { StorageAccountWrapper } from "../../utils/storageWrappers";
 import { StorageAccountTreeItem } from "../StorageAccountTreeItem";
@@ -24,7 +24,7 @@ export class StorageAccountTreeItemCreateStep extends AzureWizardExecuteStep<ISt
     }
 
     public async execute(wizardContext: IStorageAccountTreeItemCreateContext): Promise<void> {
-        const storageManagementClient = createAzureClient(this.parent.root, StorageManagementClient);
+        const storageManagementClient = await createStorageClient(wizardContext);
         wizardContext.accountTreeItem = await StorageAccountTreeItem.createStorageAccountTreeItem(this.parent, new StorageAccountWrapper(nonNullProp(wizardContext, 'storageAccount')), storageManagementClient);
     }
 

--- a/src/tree/createWizard/storageAccountCreateStep.ts
+++ b/src/tree/createWizard/storageAccountCreateStep.ts
@@ -4,9 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { StorageManagementClient, StorageManagementModels } from '@azure/arm-storage';
-import { AzureWizardExecuteStep, createAzureClient, INewStorageAccountDefaults, IStorageAccountWizardContext } from 'vscode-azureextensionui';
+import { AzureWizardExecuteStep, INewStorageAccountDefaults, IStorageAccountWizardContext } from 'vscode-azureextensionui';
 import { NotificationProgress } from '../../constants';
 import { ext } from '../../extensionVariables';
+import { createStorageClient } from '../../utils/azureClients';
 
 export class StorageAccountCreateStep<T extends IStorageAccountWizardContext> extends AzureWizardExecuteStep<T> implements StorageAccountCreateStep<T> {
     public priority: number = 130;
@@ -27,7 +28,7 @@ export class StorageAccountCreateStep<T extends IStorageAccountWizardContext> ex
         const creatingStorageAccount: string = `Creating storage account "${newName}" in location "${newLocation}" with sku "${newSkuName}"...`;
         ext.outputChannel.appendLog(creatingStorageAccount);
         progress.report({ message: creatingStorageAccount });
-        const storageClient: StorageManagementClient = createAzureClient(wizardContext, StorageManagementClient);
+        const storageClient: StorageManagementClient = await createStorageClient(wizardContext);
         wizardContext.storageAccount = await storageClient.storageAccounts.create(
             // tslint:disable-next-line:no-non-null-assertion
             wizardContext.resourceGroup!.name!,

--- a/src/tree/createWizard/storageAccountNameStep.ts
+++ b/src/tree/createWizard/storageAccountNameStep.ts
@@ -4,12 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { StorageManagementClient, StorageManagementModels } from '@azure/arm-storage';
-import { AzureNameStep, createAzureClient, IStorageAccountWizardContext, ResourceGroupListStep, resourceGroupNamingRules, storageAccountNamingRules } from 'vscode-azureextensionui';
+import { AzureNameStep, IStorageAccountWizardContext, ResourceGroupListStep, resourceGroupNamingRules, storageAccountNamingRules } from 'vscode-azureextensionui';
 import { ext } from '../../extensionVariables';
+import { createStorageClient } from '../../utils/azureClients';
 
 export class StorageAccountNameStep<T extends IStorageAccountWizardContext> extends AzureNameStep<T> {
     public async prompt(wizardContext: T): Promise<void> {
-        const client: StorageManagementClient = createAzureClient(wizardContext, StorageManagementClient);
+        const client: StorageManagementClient = await createStorageClient(wizardContext);
 
         const suggestedName: string | undefined = wizardContext.relatedNameTask ? await wizardContext.relatedNameTask : undefined;
         wizardContext.newStorageAccountName = (await ext.ui.showInputBox({

--- a/src/utils/azureClients.ts
+++ b/src/utils/azureClients.ts
@@ -1,0 +1,14 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { StorageManagementClient } from '@azure/arm-storage';
+import { createAzureClient, ISubscriptionContext } from 'vscode-azureextensionui';
+
+// Lazy-load @azure packages to improve startup performance.
+// NOTE: The client is the only import that matters, the rest of the types disappear when compiled to JavaScript
+
+export async function createStorageClient<T extends ISubscriptionContext>(context: T): Promise<StorageManagementClient> {
+    return createAzureClient(context, (await import('@azure/arm-storage')).StorageManagementClient);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,8 @@
                 "node_modules/@types/*",
                 "*"
             ]
-        }
+        },
+        "skipLibCheck": true // https://github.com/Azure/ms-rest-js/issues/367
     },
     "exclude": [
         "node_modules",


### PR DESCRIPTION
Related to https://github.com/microsoft/vscode-azuretools/pull/806

I don't actually think this will help startup performance as much as other extensions, but I want us to use this pattern in all of our extensions regardless. It could also help isolate azure stack changes inside of `createStorageClient`