### PR TITLE
Don't show 'Open resource in Storage Explorer' error action on Linux (Codespaces)

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -25,6 +25,8 @@ export const emulatorKey: string = 'Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6
 export const maxRemoteFileEditSizeMB: number = 50;
 export const maxRemoteFileEditSizeBytes: number = maxRemoteFileEditSizeMB * 1024 * 1024;
 
+export const storageExplorerDownloadUrl: string = 'https://go.microsoft.com/fwlink/?LinkId=723579';
+
 export function getResourcesPath(): string {
     return ext.context.asAbsolutePath('resources');
 }

--- a/src/storageExplorerLauncher/macOSStorageExplorerLauncher.ts
+++ b/src/storageExplorerLauncher/macOSStorageExplorerLauncher.ts
@@ -7,6 +7,7 @@ import * as fs from "fs";
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { callWithTelemetryAndErrorHandling, UserCancelledError } from "vscode-azureextensionui";
+import { storageExplorerDownloadUrl } from "../constants";
 import { Launcher } from "../utils/launcher";
 import { getSingleRootWorkspace } from "../utils/workspaceUtils";
 import { IStorageExplorerLauncher } from "./IStorageExplorerLauncher";
@@ -14,7 +15,6 @@ import { ResourceType } from "./ResourceType";
 
 export class MacOSStorageExplorerLauncher implements IStorageExplorerLauncher {
     private static subExecutableLocation: string = "/Contents/MacOS/Microsoft\ Azure\ Storage\ Explorer";
-    public static downloadPageUrl: string = "https://go.microsoft.com/fwlink/?LinkId=723579";
 
     private static async getStorageExplorerExecutable(
         warningString: string = "Cannot find Storage Explorer. Browse to existing installation location or download and install Storage Explorer."): Promise<string> {
@@ -69,7 +69,7 @@ export class MacOSStorageExplorerLauncher implements IStorageExplorerLauncher {
     }
 
     private static async downloadStorageExplorer(): Promise<void> {
-        await Launcher.launch("open", MacOSStorageExplorerLauncher.downloadPageUrl);
+        await Launcher.launch("open", storageExplorerDownloadUrl);
     }
 
     private async launchStorageExplorer(extraArgs: string[] = []): Promise<void> {

--- a/src/storageExplorerLauncher/macOSStorageExplorerLauncher.ts
+++ b/src/storageExplorerLauncher/macOSStorageExplorerLauncher.ts
@@ -9,6 +9,7 @@ import * as vscode from 'vscode';
 import { callWithTelemetryAndErrorHandling, UserCancelledError } from "vscode-azureextensionui";
 import { storageExplorerDownloadUrl } from "../constants";
 import { Launcher } from "../utils/launcher";
+import { openUrl } from "../utils/openUrl";
 import { getSingleRootWorkspace } from "../utils/workspaceUtils";
 import { IStorageExplorerLauncher } from "./IStorageExplorerLauncher";
 import { ResourceType } from "./ResourceType";
@@ -31,11 +32,12 @@ export class MacOSStorageExplorerLauncher implements IStorageExplorerLauncher {
                     let userSelectedAppLocation = await MacOSStorageExplorerLauncher.showOpenDialog();
                     await vscode.workspace.getConfiguration('azureStorage').update('storageExplorerLocation', userSelectedAppLocation, vscode.ConfigurationTarget.Global);
                     return await MacOSStorageExplorerLauncher.getStorageExplorerExecutable("Selected app is not a valid Storage Explorer installation. Browse to existing installation location or download and install Storage Explorer.");
-                } else if (selected === "Download") {
-                    context.telemetry.properties.downloadStorageExplorer = 'true';
-                    await MacOSStorageExplorerLauncher.downloadStorageExplorer();
-                    throw new UserCancelledError();
                 } else {
+                    if (selected === "Download") {
+                        context.telemetry.properties.downloadStorageExplorer = 'true';
+                        await openUrl(storageExplorerDownloadUrl);
+                    }
+
                     throw new UserCancelledError();
                 }
             }
@@ -66,10 +68,6 @@ export class MacOSStorageExplorerLauncher implements IStorageExplorerLauncher {
         await this.launchStorageExplorer([
             url
         ]);
-    }
-
-    private static async downloadStorageExplorer(): Promise<void> {
-        await Launcher.launch("open", storageExplorerDownloadUrl);
     }
 
     private async launchStorageExplorer(extraArgs: string[] = []): Promise<void> {

--- a/src/storageExplorerLauncher/windowsStorageExplorerLauncher.ts
+++ b/src/storageExplorerLauncher/windowsStorageExplorerLauncher.ts
@@ -6,13 +6,13 @@ import * as fs from "fs";
 import { MessageItem } from "vscode";
 import { callWithTelemetryAndErrorHandling, UserCancelledError } from "vscode-azureextensionui";
 import * as winreg from "winreg";
+import { storageExplorerDownloadUrl } from "../constants";
 import { ext } from "../extensionVariables";
 import { Launcher } from "../utils/launcher";
 import { localize } from "../utils/localize";
 import { IStorageExplorerLauncher } from "./IStorageExplorerLauncher";
 import { ResourceType } from "./ResourceType";
 
-const downloadPageUrl: string = "https://go.microsoft.com/fwlink/?LinkId=723579";
 const regKey: { hive: string, key: string } = { hive: "HKCR", key: "\\storageexplorer\\shell\\open\\command" };
 
 export class WindowsStorageExplorerLauncher implements IStorageExplorerLauncher {
@@ -92,7 +92,7 @@ export class WindowsStorageExplorerLauncher implements IStorageExplorerLauncher 
 
     private static async downloadStorageExplorer(): Promise<void> {
         //I'm not sure why running start directly doesn't work. Opening separate cmd to run the command works well
-        await Launcher.launch("cmd", "/c", "start", downloadPageUrl);
+        await Launcher.launch("cmd", "/c", "start", storageExplorerDownloadUrl);
     }
 
     private static async launchStorageExplorer(args: string[] = []): Promise<void> {

--- a/src/storageExplorerLauncher/windowsStorageExplorerLauncher.ts
+++ b/src/storageExplorerLauncher/windowsStorageExplorerLauncher.ts
@@ -10,6 +10,7 @@ import { storageExplorerDownloadUrl } from "../constants";
 import { ext } from "../extensionVariables";
 import { Launcher } from "../utils/launcher";
 import { localize } from "../utils/localize";
+import { openUrl } from "../utils/openUrl";
 import { IStorageExplorerLauncher } from "./IStorageExplorerLauncher";
 import { ResourceType } from "./ResourceType";
 
@@ -61,7 +62,7 @@ export class WindowsStorageExplorerLauncher implements IStorageExplorerLauncher 
                 const message: string = localize('cantFindSE', 'Cannot find a compatible Storage Explorer. Would you like to download the latest Storage Explorer?');
                 await ext.ui.showWarningMessage(message, download);
                 context.telemetry.properties.downloadStorageExplorer = 'true';
-                await WindowsStorageExplorerLauncher.downloadStorageExplorer();
+                await openUrl(storageExplorerDownloadUrl);
                 throw new UserCancelledError();
             }
             // tslint:disable-next-line: strict-boolean-expressions
@@ -88,11 +89,6 @@ export class WindowsStorageExplorerLauncher implements IStorageExplorerLauncher 
                 }
             });
         });
-    }
-
-    private static async downloadStorageExplorer(): Promise<void> {
-        //I'm not sure why running start directly doesn't work. Opening separate cmd to run the command works well
-        await Launcher.launch("cmd", "/c", "start", storageExplorerDownloadUrl);
     }
 
     private static async launchStorageExplorer(args: string[] = []): Promise<void> {

--- a/src/tree/blob/BlobTreeItem.ts
+++ b/src/tree/blob/BlobTreeItem.ts
@@ -10,7 +10,7 @@ import * as vscode from 'vscode';
 import { MessageItem, Uri, window } from 'vscode';
 import { AzureParentTreeItem, AzureTreeItem, DialogResponses, IActionContext, UserCancelledError } from 'vscode-azureextensionui';
 import { AzureStorageFS } from "../../AzureStorageFS";
-import { getResourcesPath } from "../../constants";
+import { getResourcesPath, storageExplorerDownloadUrl } from "../../constants";
 import { ext } from "../../extensionVariables";
 import { askOpenInStorageExplorer } from "../../utils/askOpenInStorageExplorer";
 import { createBlobClient, createBlockBlobClient } from '../../utils/blobUtils';
@@ -79,7 +79,7 @@ export class BlobTreeItem extends AzureTreeItem<IStorageRoot> implements ICopyUr
         context.telemetry.measurements.blobDownloadSize = props.contentLength;
         if (props.blobType && !props.blobType.toLocaleLowerCase().startsWith("block")) {
             context.telemetry.properties.invalidBlobTypeForDownload = 'true';
-            const message: string = localize('pleaseUseSE', 'Please use Storage Explorer for blobs of type "{0}".', props.blobType);
+            const message: string = localize('pleaseUseSE', 'Please use [Storage Explorer]({0}) for blobs of type "{1}".', storageExplorerDownloadUrl, props.blobType);
             await askOpenInStorageExplorer(context, message, this.root.storageAccountId, this.root.subscriptionId, 'Azure.BlobContainer', this.container.name);
         }
     }

--- a/src/utils/askOpenInStorageExplorer.ts
+++ b/src/utils/askOpenInStorageExplorer.ts
@@ -6,23 +6,17 @@
 import { platform } from "os";
 import { window } from "vscode";
 import { IActionContext, UserCancelledError } from "vscode-azureextensionui";
-import { storageExplorerDownloadUrl } from "../constants";
 import { ResourceType } from "../storageExplorerLauncher/ResourceType";
 import { storageExplorerLauncher } from "../storageExplorerLauncher/storageExplorerLauncher";
 import { localize } from "./localize";
-import { openUrl } from "./openUrl";
 
 export async function askOpenInStorageExplorer(context: IActionContext, errorMessage: string, resourceId: string, subscriptionId: string, resourceType: ResourceType, resourceName: string): Promise<void> {
-    const openMessage: string = localize('openInSE', 'Open resource in Storage Explorer');
-    const downloadMessage: string = localize('downloadSE', 'Download Storage Explorer');
-    const message: string = platform() === 'linux' ? downloadMessage : openMessage;
-    window.showErrorMessage(errorMessage, message).then(async result => {
-        if (result === openMessage) {
+    const message: string = localize("openInSE", "Open resource in Storage Explorer");
+    const items: string[] = platform() === 'linux' ? [] : [message];
+    window.showErrorMessage(errorMessage, ...items).then(async result => {
+        if (result === message) {
             context.telemetry.properties.openInStorageExplorer = 'true';
             await storageExplorerLauncher.openResource(resourceId, subscriptionId, resourceType, resourceName);
-        } else if (result === downloadMessage) {
-            context.telemetry.properties.openStorageExplorerDownloadUrl = 'true';
-            await openUrl(storageExplorerDownloadUrl);
         }
     });
 

--- a/src/utils/askOpenInStorageExplorer.ts
+++ b/src/utils/askOpenInStorageExplorer.ts
@@ -6,17 +6,23 @@
 import { platform } from "os";
 import { window } from "vscode";
 import { IActionContext, UserCancelledError } from "vscode-azureextensionui";
+import { storageExplorerDownloadUrl } from "../constants";
 import { ResourceType } from "../storageExplorerLauncher/ResourceType";
 import { storageExplorerLauncher } from "../storageExplorerLauncher/storageExplorerLauncher";
 import { localize } from "./localize";
+import { openUrl } from "./openUrl";
 
 export async function askOpenInStorageExplorer(context: IActionContext, errorMessage: string, resourceId: string, subscriptionId: string, resourceType: ResourceType, resourceName: string): Promise<void> {
-    const message: string = localize("openInSE", "Open resource in Storage Explorer");
-    const items: string[] = platform() === 'linux' ? [] : [message];
-    window.showErrorMessage(errorMessage, ...items).then(async result => {
-        if (result === message) {
+    const openMessage: string = localize('openInSE', 'Open resource in Storage Explorer');
+    const downloadMessage: string = localize('downloadSE', 'Download Storage Explorer');
+    const message: string = platform() === 'linux' ? downloadMessage : openMessage;
+    window.showErrorMessage(errorMessage, message).then(async result => {
+        if (result === openMessage) {
             context.telemetry.properties.openInStorageExplorer = 'true';
             await storageExplorerLauncher.openResource(resourceId, subscriptionId, resourceType, resourceName);
+        } else if (result === downloadMessage) {
+            context.telemetry.properties.openStorageExplorerDownloadUrl = 'true';
+            await openUrl(storageExplorerDownloadUrl);
         }
     });
 

--- a/src/utils/askOpenInStorageExplorer.ts
+++ b/src/utils/askOpenInStorageExplorer.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { platform } from "os";
 import { window } from "vscode";
 import { IActionContext, UserCancelledError } from "vscode-azureextensionui";
 import { ResourceType } from "../storageExplorerLauncher/ResourceType";
@@ -11,7 +12,8 @@ import { localize } from "./localize";
 
 export async function askOpenInStorageExplorer(context: IActionContext, errorMessage: string, resourceId: string, subscriptionId: string, resourceType: ResourceType, resourceName: string): Promise<void> {
     const message: string = localize("openInSE", "Open resource in Storage Explorer");
-    window.showErrorMessage(errorMessage, message).then(async result => {
+    const items: string[] = platform() === 'linux' ? [] : [message];
+    window.showErrorMessage(errorMessage, ...items).then(async result => {
         if (result === message) {
             context.telemetry.properties.openInStorageExplorer = 'true';
             await storageExplorerLauncher.openResource(resourceId, subscriptionId, resourceType, resourceName);


### PR DESCRIPTION
If Storage Explorer is required in Linux, an error is still thrown but without an action button to open in SE.

| Mac/Windows | Linux/Codespaces |
| - | - |
| <img width="460" alt="Screen Shot 2021-01-07 at 1 12 00 PM" src="https://user-images.githubusercontent.com/22795803/103945434-0caa7880-50ea-11eb-9c2d-4e2a72b8a715.png">| <img width="460" alt="Screen Shot 2021-01-07 at 1 09 38 PM" src="https://user-images.githubusercontent.com/22795803/103945446-10d69600-50ea-11eb-8c63-8d6660ad16c8.png"> |



Fixes https://github.com/microsoft/vscode-azurestorage/issues/896