### PR TITLE
Make AzCopy excludePath more strict

### DIFF
--- a/src/commands/azCopy/azCopyTransfer.ts
+++ b/src/commands/azCopy/azCopyTransfer.ts
@@ -33,7 +33,7 @@ export async function azCopyTransfer(
 ): Promise<void> {
     // `followSymLinks: true` causes downloads to fail (which is expected) but it currently doesn't work as expected for uploads: https://github.com/Azure/azure-storage-azcopy/issues/1174
     // So it's omitted from `copyOptions` for now
-    const copyOptions: ICopyOptions = { fromTo, overwriteExisting: "true", recursive: true, excludePath: '.git;.vscode' };
+    const copyOptions: ICopyOptions = { fromTo, overwriteExisting: "true", recursive: true, excludePath: '.git/;.vscode/' };
     const jobInfo: IJobInfo = await startAndWaitForTransfer(context, { src, dst }, copyOptions, transferProgress, notificationProgress, cancellationToken);
     await handleJob(context, jobInfo, src.path);
 }


### PR DESCRIPTION
The old `excludePath` was only supposed to exclude the .git and .vscode folders but was also excluding .github and .gitignore. So sometimes the number of finished uploads would be less than the total number of files. (the exclude path for total number of files is [here](https://github.com/microsoft/vscode-azurestorage/blob/41888f4c3ee4d632e24f8463c1b20dec765bbf1b/src/utils/uploadUtils.ts#L103))

Here's an example of a directory that has a .gitignore and .github folder:
| Old | New |
|-|-|
| <img width="409" alt="Screen Shot 2021-01-15 at 1 53 28 PM" src="https://user-images.githubusercontent.com/22795803/104782679-79042800-5739-11eb-8e6e-2482d35bb1eb.png">|<img width="409" alt="Screen Shot 2021-01-15 at 1 52 40 PM" src="https://user-images.githubusercontent.com/22795803/104782697-7dc8dc00-5739-11eb-8b90-3352839d4c5d.png">|

