### PR TITLE
Only ignore folders at the root level of the directory path being uploaded

### DIFF
--- a/src/utils/uploadUtils.ts
+++ b/src/utils/uploadUtils.ts
@@ -100,7 +100,9 @@ export async function getDestinationDirectory(destinationDirectory?: string): Pr
 
 async function getNumResourcesInDirectory(directoryPath: string, countFolders?: boolean): Promise<number> {
     const options: readdirp.ReaddirpOptions = {
-        directoryFilter: ['!.git', '!.vscode'],
+        directoryFilter: (entryInfo: readdirp.EntryInfo) => {
+            return entryInfo.path !== '.git' && entryInfo.path !== '.vscode';
+        },
         type: countFolders ? 'files_directories' : 'files'
     };
     const resources: readdirp.EntryInfo[] = await readdirp.promise(directoryPath, options);


### PR DESCRIPTION
The code that gets the number of resources in a directory was using glob patterns. These patterns would ignore `.git` and `.vscode` directories at any level in the tree structure.

There was a discrepancy between this number and the number of resources uploaded by AzCopy because AzCopy does not recursively match the exclude path and does not provide a way to do so. From the AzCopy CLI:

> ```      
> --exclude-path string          Exclude these paths when copying. This option does not support wildcard characters (*).  Checks relative path prefix(For example: myFolder;myFolder/subDirName/file.pdf)...
> ```

So I decided to only ignore `.git` and `.vscode` directories at the root level since we can't ignore them anywhere else in the tree.

Here's what it looks like to upload a single git repo followed by a folder with multiple repos in it. The old version of uploading `multiRepoTest` was waay off because none of the git files in each repo were included in the total.

| Old | New |
| - | - |
| ![Screen Shot 2021-01-26 at 4 29 38 PM](https://user-images.githubusercontent.com/22795803/105925022-4806db80-5ff4-11eb-9621-5e0bbf1e9f9a.png) | ![Screen Shot 2021-01-26 at 4 31 29 PM](https://user-images.githubusercontent.com/22795803/105925035-4ccb8f80-5ff4-11eb-8cf6-848e6bb5bd2b.png) |

Fixes https://github.com/microsoft/vscode-azurestorage/issues/873
