### PR TITLE
Show link to wiki when AzCopy fails (with no explanation) on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,16 @@ Use these configuration settings to customize the Azure Storage extension.
 * `azureStorage.file.showSavePrompt`: Set to `false` to prevent showing a warning dialog on File file save.
 * `azureStorage.blob.showSavePrompt`: Set to `false` to prevent showing a warning dialog on Blob file save.
 
+## Known Issues
+
+* `libsecret-1-dev` is required for AzCopy transfers on Linux and is not installed by default in many distros running in WSL.
+To install it on Debian based distros, run
+
+    ```
+    sudo apt update
+    sudo apt install libsecret-1-dev
+    ```
+
 <!-- region exclude-from-marketplace -->
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -62,16 +62,6 @@ Use these configuration settings to customize the Azure Storage extension.
 * `azureStorage.file.showSavePrompt`: Set to `false` to prevent showing a warning dialog on File file save.
 * `azureStorage.blob.showSavePrompt`: Set to `false` to prevent showing a warning dialog on Blob file save.
 
-## Known Issues
-
-* `libsecret-1-dev` is required for AzCopy transfers on Linux and is not installed by default in many distros running in WSL.
-To install it on Debian based distros, run
-
-    ```
-    sudo apt update
-    sudo apt install libsecret-1-dev
-    ```
-
 <!-- region exclude-from-marketplace -->
 
 ## Contributing

--- a/src/commands/azCopy/azCopyTransfer.ts
+++ b/src/commands/azCopy/azCopyTransfer.ts
@@ -44,6 +44,8 @@ async function handleJob(context: IActionContext, jobInfo: IJobInfo, transferLab
     if (!finalTransferStatus || finalTransferStatus.JobStatus !== 'Completed') {
         // tslint:disable-next-line: strict-boolean-expressions
         let message: string = jobInfo.errorMessage || localize('azCopyTransfer', 'AzCopy Transfer: "{0}". ', finalTransferStatus?.JobStatus || 'Failed');
+        const originalMessage: string = message;
+
         if (finalTransferStatus?.FailedTransfers?.length || finalTransferStatus?.SkippedTransfers?.length) {
             message += localize('checkOutputWindow', ' Check the [output window](command:{0}) for a list of incomplete transfers.', `${ext.prefix}.showOutputChannel`);
 
@@ -75,8 +77,9 @@ async function handleJob(context: IActionContext, jobInfo: IJobInfo, transferLab
             // tslint:disable-next-line: no-floating-promises
             ext.ui.showWarningMessage(message);
         } else {
-            if (/^AzCopy Transfer: "Failed"\.\s$/i.test(message) && process.platform === 'linux') {
-                message += localize('viewTheWiki', 'View [the wiki](https://github.com/microsoft/vscode-azurestorage/wiki/Known-Issues) for help with known issues.');
+            const isDefaultFailMessage: boolean = !jobInfo.errorMessage && /failed/i.test(message) && message === originalMessage;
+            if (isDefaultFailMessage && process.platform === 'linux') {
+                message += localize('viewHelp', 'View help with [known issues](https://aka.ms/AAb0i6o).');
             }
 
             throw new Error(message);

--- a/src/commands/azCopy/azCopyTransfer.ts
+++ b/src/commands/azCopy/azCopyTransfer.ts
@@ -75,6 +75,10 @@ async function handleJob(context: IActionContext, jobInfo: IJobInfo, transferLab
             // tslint:disable-next-line: no-floating-promises
             ext.ui.showWarningMessage(message);
         } else {
+            if (/^AzCopy Transfer: "Failed"\.\s$/i.test(message) && process.platform === 'linux') {
+                message += localize('viewTheWiki', 'View [the wiki](https://github.com/microsoft/vscode-azurestorage/wiki/Known-Issues) for help with known issues.');
+            }
+
             throw new Error(message);
         }
     }


### PR DESCRIPTION
Related: https://github.com/microsoft/vscode-azurestorage/issues/917

After looking into it more, I was hesitant to auto-detect this package because you have to use that distro's package manager to query the installed packages. This varies based on the distro and keeping all of those commands up to date sounds like a can 'o worms 🪱 

