### PR TITLE
Update 'must install Azurite' prompt

### DIFF
--- a/src/commands/blob/blobContainerGroupActionHandlers.ts
+++ b/src/commands/blob/blobContainerGroupActionHandlers.ts
@@ -5,12 +5,12 @@
 
 import { IActionContext, registerCommand } from 'vscode-azureextensionui';
 import { BlobContainerGroupTreeItem } from '../../tree/blob/BlobContainerGroupTreeItem';
+import { isAzuriteInstalled, warnAzuriteNotInstalled } from '../../utils/azuriteUtils';
 import { createChildNode } from '../commonTreeCommands';
-import { isAzuriteCliInstalled, isAzuriteExtensionInstalled, warnAzuriteNotInstalled } from '../startEmulator';
 
 export function registerBlobContainerGroupActionHandlers(): void {
     registerCommand("azureStorage.createBlobContainer", async (context: IActionContext, treeItem?: BlobContainerGroupTreeItem) => {
-        if (treeItem?.root.isEmulated && !isAzuriteExtensionInstalled() && !(await isAzuriteCliInstalled())) {
+        if (treeItem?.root.isEmulated && !(await isAzuriteInstalled())) {
             warnAzuriteNotInstalled(context);
         }
         await createChildNode(context, BlobContainerGroupTreeItem.contextValue, treeItem)

--- a/src/commands/blob/blobContainerGroupActionHandlers.ts
+++ b/src/commands/blob/blobContainerGroupActionHandlers.ts
@@ -6,7 +6,13 @@
 import { IActionContext, registerCommand } from 'vscode-azureextensionui';
 import { BlobContainerGroupTreeItem } from '../../tree/blob/BlobContainerGroupTreeItem';
 import { createChildNode } from '../commonTreeCommands';
+import { isAzuriteCliInstalled, isAzuriteExtensionInstalled, warnAzuriteNotInstalled } from '../startEmulator';
 
 export function registerBlobContainerGroupActionHandlers(): void {
-    registerCommand("azureStorage.createBlobContainer", async (context: IActionContext, treeItem?: BlobContainerGroupTreeItem) => await createChildNode(context, BlobContainerGroupTreeItem.contextValue, treeItem));
+    registerCommand("azureStorage.createBlobContainer", async (context: IActionContext, treeItem?: BlobContainerGroupTreeItem) => {
+        if (treeItem?.root.isEmulated && !isAzuriteExtensionInstalled() && !(await isAzuriteCliInstalled())) {
+            warnAzuriteNotInstalled(context);
+        }
+        await createChildNode(context, BlobContainerGroupTreeItem.contextValue, treeItem)
+    });
 }

--- a/src/commands/queue/queueGroupActionHandlers.ts
+++ b/src/commands/queue/queueGroupActionHandlers.ts
@@ -5,12 +5,12 @@
 
 import { IActionContext, registerCommand } from 'vscode-azureextensionui';
 import { QueueGroupTreeItem } from '../../tree/queue/QueueGroupTreeItem';
+import { isAzuriteInstalled, warnAzuriteNotInstalled } from '../../utils/azuriteUtils';
 import { createChildNode } from '../commonTreeCommands';
-import { isAzuriteCliInstalled, isAzuriteExtensionInstalled, warnAzuriteNotInstalled } from '../startEmulator';
 
 export function registerQueueGroupActionHandlers(): void {
     registerCommand("azureStorage.createQueue", async (context: IActionContext, treeItem?: QueueGroupTreeItem) => {
-        if (treeItem?.root.isEmulated && !isAzuriteExtensionInstalled() && !(await isAzuriteCliInstalled())) {
+        if (treeItem?.root.isEmulated && !(await isAzuriteInstalled())) {
             warnAzuriteNotInstalled(context);
         }
         await createChildNode(context, QueueGroupTreeItem.contextValue, treeItem)

--- a/src/commands/queue/queueGroupActionHandlers.ts
+++ b/src/commands/queue/queueGroupActionHandlers.ts
@@ -6,7 +6,13 @@
 import { IActionContext, registerCommand } from 'vscode-azureextensionui';
 import { QueueGroupTreeItem } from '../../tree/queue/QueueGroupTreeItem';
 import { createChildNode } from '../commonTreeCommands';
+import { isAzuriteCliInstalled, isAzuriteExtensionInstalled, warnAzuriteNotInstalled } from '../startEmulator';
 
 export function registerQueueGroupActionHandlers(): void {
-    registerCommand("azureStorage.createQueue", async (context: IActionContext, treeItem?: QueueGroupTreeItem) => await createChildNode(context, QueueGroupTreeItem.contextValue, treeItem));
+    registerCommand("azureStorage.createQueue", async (context: IActionContext, treeItem?: QueueGroupTreeItem) => {
+        if (treeItem?.root.isEmulated && !isAzuriteExtensionInstalled() && !(await isAzuriteCliInstalled())) {
+            warnAzuriteNotInstalled(context);
+        }
+        await createChildNode(context, QueueGroupTreeItem.contextValue, treeItem)
+    });
 }

--- a/src/commands/startEmulator.ts
+++ b/src/commands/startEmulator.ts
@@ -5,12 +5,10 @@
 
 import * as vscode from 'vscode';
 import { IActionContext } from 'vscode-azureextensionui';
+import { emulatorTimeoutMS } from '../constants';
 import { ext } from "../extensionVariables";
+import { isAzuriteCliInstalled, isAzuriteExtensionInstalled, warnAzuriteNotInstalled } from '../utils/azuriteUtils';
 import { cpUtils } from '../utils/cpUtils';
-import { localize } from '../utils/localize';
-
-export const azuriteExtensionId: string = 'Azurite.azurite';
-export const emulatorTimeoutMS: number = 3 * 1000;
 
 export async function startEmulator(context: IActionContext, emulatorType: EmulatorType): Promise<void> {
     if (isAzuriteExtensionInstalled()) {
@@ -32,26 +30,6 @@ export async function startEmulator(context: IActionContext, emulatorType: Emula
     } else {
         warnAzuriteNotInstalled(context);
     }
-}
-
-export function isAzuriteExtensionInstalled(): boolean {
-    return !!vscode.extensions.getExtension(azuriteExtensionId);
-}
-
-export async function isAzuriteCliInstalled(): Promise<boolean> {
-    try {
-        await cpUtils.executeCommand(undefined, undefined, 'azurite -v');
-        return true;
-    } catch {
-        return false;
-    }
-}
-
-export function warnAzuriteNotInstalled(context: IActionContext): void {
-    void ext.ui.showWarningMessage(localize('mustInstallAzurite', 'You must install the [Azurite extension](command:azureStorage.showAzuriteExtension) to perform this operation.'));
-    context.telemetry.properties.cancelStep = 'installAzuriteExtension';
-    context.errorHandling.suppressDisplay = true;
-    throw new Error(`"${azuriteExtensionId}" extension is not installed.`);
 }
 
 export enum EmulatorType {

--- a/src/commands/startEmulator.ts
+++ b/src/commands/startEmulator.ts
@@ -4,20 +4,20 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import { IActionContext, UserCancelledError } from 'vscode-azureextensionui';
+import { IActionContext } from 'vscode-azureextensionui';
 import { ext } from "../extensionVariables";
 import { cpUtils } from '../utils/cpUtils';
 import { localize } from '../utils/localize';
 
-const azuriteExtensionId: string = 'Azurite.azurite';
+export const azuriteExtensionId: string = 'Azurite.azurite';
 export const emulatorTimeoutMS: number = 3 * 1000;
 
 export async function startEmulator(context: IActionContext, emulatorType: EmulatorType): Promise<void> {
-    if (vscode.extensions.getExtension(azuriteExtensionId)) {
+    if (isAzuriteExtensionInstalled()) {
         // Use the Azurite extension
         await vscode.commands.executeCommand(`azurite.start_${emulatorType}`);
         await ext.tree.refresh(context, ext.attachedStorageAccountsTreeItem);
-    } else if (await azuriteCLIInstalled()) {
+    } else if (await isAzuriteCliInstalled()) {
         // Use the Azurite CLI
 
         // This task will remain active as long as the user keeps the emulator running. Only show an error if it happens in the first three seconds
@@ -30,25 +30,28 @@ export async function startEmulator(context: IActionContext, emulatorType: Emula
 
         await ext.tree.refresh(context, ext.attachedStorageAccountsTreeItem);
     } else {
-        const installAzurite: vscode.MessageItem = { title: localize('installAzurite', 'Install Azurite') };
-        const message: string = localize('mustInstallAzurite', 'You must install Azurite to start the storage emulator from VS Code.');
-
-        const result: vscode.MessageItem = await ext.ui.showWarningMessage(message, { modal: true }, installAzurite);
-        if (result === installAzurite) {
-            context.telemetry.properties.cancelStep = 'installAzuriteExtension';
-            await vscode.commands.executeCommand('extension.open', azuriteExtensionId);
-            throw new UserCancelledError();
-        }
+        warnAzuriteNotInstalled(context);
     }
 }
 
-async function azuriteCLIInstalled(): Promise<boolean> {
+export function isAzuriteExtensionInstalled(): boolean {
+    return !!vscode.extensions.getExtension(azuriteExtensionId);
+}
+
+export async function isAzuriteCliInstalled(): Promise<boolean> {
     try {
         await cpUtils.executeCommand(undefined, undefined, 'azurite -v');
         return true;
     } catch {
         return false;
     }
+}
+
+export function warnAzuriteNotInstalled(context: IActionContext): void {
+    void ext.ui.showWarningMessage(localize('mustInstallAzurite', 'You must install the [Azurite extension](command:azureStorage.showAzuriteExtension) to perform this operation.'));
+    context.telemetry.properties.cancelStep = 'installAzuriteExtension';
+    context.errorHandling.suppressDisplay = true;
+    throw new Error(`"${azuriteExtensionId}" extension is not installed.`);
 }
 
 export enum EmulatorType {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,6 +18,8 @@ export enum configurationSettingsKeys {
 
 export const extensionPrefix: string = 'azureStorage';
 
+export const azuriteExtensionId: string = 'Azurite.azurite';
+export const emulatorTimeoutMS: number = 3 * 1000;
 export const emulatorAccountName: string = 'devstoreaccount1';
 export const emulatorConnectionString: string = 'UseDevelopmentStorage=true;';
 export const emulatorKey: string = 'Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,7 +27,7 @@ import { OpenTreeItemStep } from './commands/openInFileExplorer/OpenTreeItemStep
 import { registerQueueActionHandlers } from './commands/queue/queueActionHandlers';
 import { registerQueueGroupActionHandlers } from './commands/queue/queueGroupActionHandlers';
 import { selectStorageAccountTreeItemForCommand } from './commands/selectStorageAccountNodeForCommand';
-import { emulatorTimeoutMS as startEmulatorDebounce, EmulatorType, startEmulator } from './commands/startEmulator';
+import { azuriteExtensionId, emulatorTimeoutMS as startEmulatorDebounce, EmulatorType, startEmulator } from './commands/startEmulator';
 import { registerStorageAccountActionHandlers } from './commands/storageAccountActionHandlers';
 import { registerTableActionHandlers } from './commands/table/tableActionHandlers';
 import { registerTableGroupActionHandlers } from './commands/table/tableGroupActionHandlers';
@@ -147,6 +147,7 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
     registerCommand('azureStorage.detachStorageAccount', detachStorageAccount);
     registerCommand('azureStorage.startBlobEmulator', async (actionContext: IActionContext) => { await startEmulator(actionContext, EmulatorType.blob); }, startEmulatorDebounce);
     registerCommand('azureStorage.startQueueEmulator', async (actionContext: IActionContext) => { await startEmulator(actionContext, EmulatorType.queue); }, startEmulatorDebounce);
+    registerCommand('azureStorage.showAzuriteExtension', async () => { await commands.executeCommand('extension.open', azuriteExtensionId); });
 
     return createApiProvider([<AzureExtensionApi>{
         revealTreeItem,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,13 +27,14 @@ import { OpenTreeItemStep } from './commands/openInFileExplorer/OpenTreeItemStep
 import { registerQueueActionHandlers } from './commands/queue/queueActionHandlers';
 import { registerQueueGroupActionHandlers } from './commands/queue/queueGroupActionHandlers';
 import { selectStorageAccountTreeItemForCommand } from './commands/selectStorageAccountNodeForCommand';
-import { azuriteExtensionId, emulatorTimeoutMS as startEmulatorDebounce, EmulatorType, startEmulator } from './commands/startEmulator';
+import { EmulatorType, startEmulator } from './commands/startEmulator';
 import { registerStorageAccountActionHandlers } from './commands/storageAccountActionHandlers';
 import { registerTableActionHandlers } from './commands/table/tableActionHandlers';
 import { registerTableGroupActionHandlers } from './commands/table/tableGroupActionHandlers';
 import { uploadFiles } from './commands/uploadFiles';
 import { uploadFolder } from './commands/uploadFolder';
 import { uploadToAzureStorage } from './commands/uploadToAzureStorage';
+import { azuriteExtensionId, emulatorTimeoutMS as startEmulatorDebounce } from './constants';
 import { ext } from './extensionVariables';
 import { AzureAccountTreeItem } from './tree/AzureAccountTreeItem';
 import { BlobContainerTreeItem } from './tree/blob/BlobContainerTreeItem';

--- a/src/utils/azuriteUtils.ts
+++ b/src/utils/azuriteUtils.ts
@@ -1,0 +1,35 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { extensions } from "vscode";
+import { IActionContext } from "vscode-azureextensionui";
+import { azuriteExtensionId } from "../constants";
+import { ext } from "../extensionVariables";
+import { cpUtils } from "./cpUtils";
+import { localize } from "./localize";
+
+export async function isAzuriteInstalled(): Promise<boolean> {
+    return isAzuriteExtensionInstalled() || await isAzuriteCliInstalled();
+}
+
+export function isAzuriteExtensionInstalled(): boolean {
+    return !!extensions.getExtension(azuriteExtensionId);
+}
+
+export async function isAzuriteCliInstalled(): Promise<boolean> {
+    try {
+        await cpUtils.executeCommand(undefined, undefined, 'azurite -v');
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+export function warnAzuriteNotInstalled(context: IActionContext): void {
+    void ext.ui.showWarningMessage(localize('mustInstallAzurite', 'You must install the [Azurite extension](command:azureStorage.showAzuriteExtension) to perform this operation.'));
+    context.telemetry.properties.cancelStep = 'installAzuriteExtension';
+    context.errorHandling.suppressDisplay = true;
+    throw new Error(`"${azuriteExtensionId}" extension is not installed.`);
+}


### PR DESCRIPTION
This also adds an install prompt if you try to create an emulated queue or blob container without Azurite installed.

Fixes https://github.com/microsoft/vscode-azurestorage/issues/928
Fixes https://github.com/microsoft/vscode-azurestorage/issues/929
