### PR TITLE
 Add AntiMalware Scanner to build

### DIFF
--- a/.azure-pipelines/common/package.yml
+++ b/.azure-pipelines/common/package.yml
@@ -30,4 +30,5 @@ steps:
   inputs:
     PathtoPublish: '$(build.artifactstagingdirectory)'
     ArtifactName: vsix
-  condition: ne(variables['System.PullRequest.IsFork'], 'True')
+  # Only publish vsix from linux build since we use this to release and want to stay consistent
+  condition: and(eq(variables['Agent.OS'], 'Linux'), ne(variables['System.PullRequest.IsFork'], 'True'))

--- a/.azure-pipelines/common/package.yml
+++ b/.azure-pipelines/common/package.yml
@@ -1,11 +1,12 @@
 steps:
-- script: |
+- bash: |
     npm install --force @azure-tools/azcopy-darwin \
       @azure-tools/azcopy-linux \
       @azure-tools/azcopy-win32 \
       @azure-tools/azcopy-win64
     sudo chmod u+x node_modules/@azure-tools/azcopy-darwin/dist/bin/azcopy_darwin_amd64 \
       node_modules/@azure-tools/azcopy-linux/dist/bin/azcopy_linux_amd64
+  displayName: 'Install azcopy'
 
 - task: Npm@1
   displayName: 'cleanReadme'

--- a/.azure-pipelines/common/package.yml
+++ b/.azure-pipelines/common/package.yml
@@ -4,7 +4,7 @@ steps:
       @azure-tools/azcopy-linux \
       @azure-tools/azcopy-win32 \
       @azure-tools/azcopy-win64
-    sudo chmod u+x node_modules/@azure-tools/azcopy-darwin/dist/bin/azcopy_darwin_amd64 \
+    chmod u+x node_modules/@azure-tools/azcopy-darwin/dist/bin/azcopy_darwin_amd64 \
       node_modules/@azure-tools/azcopy-linux/dist/bin/azcopy_linux_amd64
   displayName: 'Install azcopy'
 

--- a/.azure-pipelines/compliance/compliance.yml
+++ b/.azure-pipelines/compliance/compliance.yml
@@ -17,6 +17,14 @@ steps:
   continueOnError: true
   condition: eq(variables['ENABLE_COMPLIANCE'], 'true')
 
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-antimalware.AntiMalware@3
+  displayName: 'AntiMalware Scanner'
+  inputs:
+    FileDirPath: '$(Build.SourcesDirectory)'
+    EnableServices: true
+  continueOnError: true
+  condition: eq(variables['ENABLE_COMPLIANCE'], 'true')
+
 - task: securedevelopmentteam.vss-secure-development-tools.build-task-publishsecurityanalysislogs.PublishSecurityAnalysisLogs@2
   displayName: 'Publish Security Analysis Logs'
   condition: eq(variables['ENABLE_COMPLIANCE'], 'true')

--- a/.azure-pipelines/main.yml
+++ b/.azure-pipelines/main.yml
@@ -9,6 +9,7 @@ jobs:
     vmImage: windows-latest
   steps:
   - template: common/build.yml
+  - template: common/package.yml
   - template: common/lint.yml
   - template: compliance/compliance.yml # Only works on Windows
   - template: common/test.yml
@@ -18,7 +19,7 @@ jobs:
     vmImage: ubuntu-latest
   steps:
   - template: common/build.yml
-  - template: common/publish-vsix.yml # Only publish vsix from linux build since we use this to release and want to stay consistent
+  - template: common/package.yml
   - template: common/lint.yml
   - template: common/test.yml
 
@@ -27,6 +28,7 @@ jobs:
     vmImage: macOS-latest
   steps:
   - template: common/build.yml
+  - template: common/package.yml
   - template: common/lint.yml
   - template: common/test.yml
 


### PR DESCRIPTION
Same as microsoft/vscode-azurefunctions#2769

Since `package.yml` is now run on all OS's, I had to modify the azcopy step a bit to work on Windows. This is probably a good sign because it means the malware scanner will run against the azcopy bits, too.