### PR TITLE
Update check for showing 'known issues' link (AzCopy)

### DIFF
--- a/src/commands/azCopy/azCopyTransfer.ts
+++ b/src/commands/azCopy/azCopyTransfer.ts
@@ -62,8 +62,7 @@ function handleJob(context: IActionContext, jobInfo: IJobInfo, transferLabel: st
             // Add an additional error log since we don't have any more info about the failure
             ext.outputChannel.appendLog(localize('couldNotTransfer', 'Could not transfer "{0}"', transferLabel));
 
-            const isDefaultFailMessage: boolean = !finalTransferStatus?.ErrorMsg && finalTransferStatus?.JobStatus === 'Failed';
-            if (isDefaultFailMessage && process.platform === 'linux') {
+            if (finalTransferStatus?.JobStatus === 'Failed' && process.platform === 'linux') {
                 message += localize('viewHelp', ' View help with [known issues](https://aka.ms/AAb0i6o).');
             }
         }

--- a/src/commands/azCopy/azCopyTransfer.ts
+++ b/src/commands/azCopy/azCopyTransfer.ts
@@ -62,9 +62,9 @@ function handleJob(context: IActionContext, jobInfo: IJobInfo, transferLabel: st
             // Add an additional error log since we don't have any more info about the failure
             ext.outputChannel.appendLog(localize('couldNotTransfer', 'Could not transfer "{0}"', transferLabel));
 
-            const isDefaultFailMessage: boolean = !jobInfo.errorMessage && finalTransferStatus?.JobStatus === 'Failed';
+            const isDefaultFailMessage: boolean = !finalTransferStatus?.ErrorMsg && finalTransferStatus?.JobStatus === 'Failed';
             if (isDefaultFailMessage && process.platform === 'linux') {
-                message += localize('viewHelp', 'View help with [known issues](https://aka.ms/AAb0i6o).');
+                message += localize('viewHelp', ' View help with [known issues](https://aka.ms/AAb0i6o).');
             }
         }
 


### PR DESCRIPTION
`jobInfo.errorMessage` didn't used to be set for this type of failure. This check should cover more unexpected failures than what we were looking for previously. But I wouldn't be surprised if this error message behavior changes again

<img width="452" alt="Screen Shot 2021-05-25 at 3 59 51 PM" src="https://user-images.githubusercontent.com/22795803/119579422-313e7e80-bd73-11eb-80da-00aac4502fe5.png">
