### PR TITLE
Run Azurite in loose mode to workaround 'Failed with code "500"' error

### DIFF
--- a/src/commands/startEmulator.ts
+++ b/src/commands/startEmulator.ts
@@ -5,21 +5,27 @@
 
 import * as vscode from 'vscode';
 import { IActionContext } from 'vscode-azureextensionui';
-import { emulatorTimeoutMS } from '../constants';
+import { azuriteExtensionPrefix, azuriteLooseSetting, emulatorTimeoutMS } from '../constants';
 import { ext } from "../extensionVariables";
 import { isAzuriteCliInstalled, isAzuriteExtensionInstalled, warnAzuriteNotInstalled } from '../utils/azuriteUtils';
 import { cpUtils } from '../utils/cpUtils';
+import { updateWorkspaceSetting } from '../utils/settingsUtils';
 
 export async function startEmulator(context: IActionContext, emulatorType: EmulatorType): Promise<void> {
     if (isAzuriteExtensionInstalled()) {
         // Use the Azurite extension
-        await vscode.commands.executeCommand(`azurite.start_${emulatorType}`);
+
+        // Enable loose mode (workaround for https://github.com/Azure/Azurite/issues/676)
+        await updateWorkspaceSetting(azuriteLooseSetting, true, '', azuriteExtensionPrefix);
+
+        await vscode.commands.executeCommand(`${azuriteExtensionPrefix}.start_${emulatorType}`);
         await ext.tree.refresh(context, ext.attachedStorageAccountsTreeItem);
     } else if (await isAzuriteCliInstalled()) {
         // Use the Azurite CLI
 
         // This task will remain active as long as the user keeps the emulator running. Only show an error if it happens in the first three seconds
-        const emulatorTask: Promise<string> = cpUtils.executeCommand(ext.outputChannel, undefined, `azurite-${emulatorType}`);
+        // Enable loose mode (workaround for https://github.com/Azure/Azurite/issues/676)
+        const emulatorTask: Promise<string> = cpUtils.executeCommand(ext.outputChannel, undefined, `azurite-${emulatorType} --${azuriteLooseSetting}`);
         ext.outputChannel.show();
         await new Promise((resolve: (value: unknown) => void, reject: (error: unknown) => void) => {
             emulatorTask.catch(reject);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -19,6 +19,8 @@ export enum configurationSettingsKeys {
 export const extensionPrefix: string = 'azureStorage';
 
 export const azuriteExtensionId: string = 'Azurite.azurite';
+export const azuriteExtensionPrefix: string = 'azurite';
+export const azuriteLooseSetting: string = 'loose';
 export const emulatorTimeoutMS: number = 3 * 1000;
 export const emulatorAccountName: string = 'devstoreaccount1';
 export const emulatorConnectionString: string = 'UseDevelopmentStorage=true;';


### PR DESCRIPTION
This issue would happen anytime you tried creating a new emulated blob. It's being tracked on Azurite [here](https://github.com/Azure/Azurite/issues/676). Until it's fixed there, we can workaround by running Azurite in loose mode.