### PR TITLE
Bump VS Code and Node.js version 

### DIFF
--- a/.azure-pipelines/common/build.yml
+++ b/.azure-pipelines/common/build.yml
@@ -1,8 +1,8 @@
 steps:
 - task: NodeTool@0
-  displayName: 'Use Node 12.x'
+  displayName: 'Use Node 14.x'
   inputs:
-    versionSpec: 12.x
+    versionSpec: 14.x
 
 - task: Npm@1
   displayName: 'npm ci'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Unreleased
+
+### Changed
+- Minimum version of VS Code is now 1.57.0
+
 ## 0.12.1 - 2021-06-10
 ### Added
 - Support for Azure Stack

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
                 "mime": "^2.4.4",
                 "open": "^8.0.4",
                 "p-retry": "^4.2.0",
-                "vscode-azureextensionui": "^0.46.0",
+                "vscode-azureextensionui": "^0.48.0",
                 "vscode-nls": "^4.1.1",
                 "winreg": "^1.2.3"
             },
@@ -31,9 +31,9 @@
                 "@types/gulp": "^4.0.6",
                 "@types/keytar": "4.0.1",
                 "@types/mocha": "^7.0.2",
-                "@types/node": "^12.0.0",
+                "@types/node": "^14.0.0",
                 "@types/p-retry": "^3.0.1",
-                "@types/vscode": "1.48.0",
+                "@types/vscode": "1.57.0",
                 "@types/winreg": "1.2.30",
                 "@typescript-eslint/eslint-plugin": "^4.28.3",
                 "copy-webpack-plugin": "^6.0.0",
@@ -46,13 +46,13 @@
                 "ts-node": "^7.0.1",
                 "typescript": "^4.3.5",
                 "vsce": "^1.87.0",
-                "vscode-azureextensiondev": "^0.9.5",
+                "vscode-azureextensiondev": "^0.10.0",
                 "vscode-test": "^1.5.2",
                 "webpack": "^5.28.0",
                 "webpack-cli": "^4.6.0"
             },
             "engines": {
-                "vscode": "^1.48.0"
+                "vscode": "^1.57.0"
             }
         },
         "node_modules/@azure-tools/azcopy-darwin": {
@@ -727,9 +727,9 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "12.20.7",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.7.tgz",
-            "integrity": "sha512-gWL8VUkg8VRaCAUgG9WmhefMqHmMblxe2rVpMF86nZY/+ZysU+BkAp+3cz03AixWDSSz0ks5WX59yAhv/cDwFA=="
+            "version": "14.17.9",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.9.tgz",
+            "integrity": "sha512-CMjgRNsks27IDwI785YMY0KLt3co/c0cQ5foxHYv/shC2w8oOnVwz5Ubq1QG5KzrcW+AXk6gzdnxIkDnTvzu3g=="
         },
         "node_modules/@types/node-fetch": {
             "version": "2.5.5",
@@ -829,9 +829,9 @@
             }
         },
         "node_modules/@types/vscode": {
-            "version": "1.48.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.48.0.tgz",
-            "integrity": "sha512-sZJKzsJz1gSoFXcOJWw3fnKl2sseUgZmvB4AJZS+Fea+bC/jfGPVhmFL/FfQHld/TKtukVONsmoD3Pkyx9iadg==",
+            "version": "1.57.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.57.0.tgz",
+            "integrity": "sha512-FeznBFtIDCWRluojTsi9c3LLcCHOXP5etQfBK42+ixo1CoEAchkw39tuui9zomjZuKfUVL33KZUDIwHZ/xvOkQ==",
             "dev": true
         },
         "node_modules/@types/webpack": {
@@ -10762,9 +10762,9 @@
             }
         },
         "node_modules/vscode-azureextensiondev": {
-            "version": "0.9.5",
-            "resolved": "https://registry.npmjs.org/vscode-azureextensiondev/-/vscode-azureextensiondev-0.9.5.tgz",
-            "integrity": "sha512-UuMhKgLo63wPrROyWGSau7B3YNNliZIvaX7GN+xYpKU+puerN1i7+aMbrEkHN5zbN3K8e05mK7NCEoppi/7cXg==",
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/vscode-azureextensiondev/-/vscode-azureextensiondev-0.10.0.tgz",
+            "integrity": "sha512-xlu1TZhTjnYtEWLnBhC4tqEafGwNcVi/J9Z1pzTtapDCDiTKTR5NS0FMmqJgKGaiaJG2Kidcv/rF6qSbid1KJA==",
             "dev": true,
             "dependencies": {
                 "@azure/arm-subscriptions": "^2.0.0",
@@ -10780,9 +10780,9 @@
             }
         },
         "node_modules/vscode-azureextensionui": {
-            "version": "0.46.0",
-            "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.46.0.tgz",
-            "integrity": "sha512-UJkslUvo1oNvPNoyye5UKbWa9ESGoEE7jD1Q8bkHCDAfzRWiEOLe4kEIpQvMqFYEecWTSsVRsbDA1jpGlAWkqw==",
+            "version": "0.48.0",
+            "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.48.0.tgz",
+            "integrity": "sha512-8OAeuGZZambaRWB7SAJV9Nv6RpxfoHkEYVRBjICf9UH2g8D6A0viVerm7VEzM8gyFcBYpgqkqXXR9dHwwUgKQg==",
             "dependencies": {
                 "@azure/arm-resources": "^3.0.0",
                 "@azure/arm-resources-profile-2020-09-01-hybrid": "^1.0.0",
@@ -10797,9 +10797,18 @@
                 "html-to-text": "^5.1.1",
                 "open": "^8.0.4",
                 "semver": "^5.7.1",
+                "uuid": "^8.3.2",
                 "vscode-extension-telemetry": "^0.1.7",
                 "vscode-nls": "^4.1.1",
                 "vscode-tas-client": "^0.1.22"
+            }
+        },
+        "node_modules/vscode-azureextensionui/node_modules/uuid": {
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "bin": {
+                "uuid": "dist/bin/uuid"
             }
         },
         "node_modules/vscode-extension-telemetry": {
@@ -12033,9 +12042,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "12.20.7",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.7.tgz",
-            "integrity": "sha512-gWL8VUkg8VRaCAUgG9WmhefMqHmMblxe2rVpMF86nZY/+ZysU+BkAp+3cz03AixWDSSz0ks5WX59yAhv/cDwFA=="
+            "version": "14.17.9",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.9.tgz",
+            "integrity": "sha512-CMjgRNsks27IDwI785YMY0KLt3co/c0cQ5foxHYv/shC2w8oOnVwz5Ubq1QG5KzrcW+AXk6gzdnxIkDnTvzu3g=="
         },
         "@types/node-fetch": {
             "version": "2.5.5",
@@ -12134,9 +12143,9 @@
             }
         },
         "@types/vscode": {
-            "version": "1.48.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.48.0.tgz",
-            "integrity": "sha512-sZJKzsJz1gSoFXcOJWw3fnKl2sseUgZmvB4AJZS+Fea+bC/jfGPVhmFL/FfQHld/TKtukVONsmoD3Pkyx9iadg==",
+            "version": "1.57.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.57.0.tgz",
+            "integrity": "sha512-FeznBFtIDCWRluojTsi9c3LLcCHOXP5etQfBK42+ixo1CoEAchkw39tuui9zomjZuKfUVL33KZUDIwHZ/xvOkQ==",
             "dev": true
         },
         "@types/webpack": {
@@ -20045,9 +20054,9 @@
             }
         },
         "vscode-azureextensiondev": {
-            "version": "0.9.5",
-            "resolved": "https://registry.npmjs.org/vscode-azureextensiondev/-/vscode-azureextensiondev-0.9.5.tgz",
-            "integrity": "sha512-UuMhKgLo63wPrROyWGSau7B3YNNliZIvaX7GN+xYpKU+puerN1i7+aMbrEkHN5zbN3K8e05mK7NCEoppi/7cXg==",
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/vscode-azureextensiondev/-/vscode-azureextensiondev-0.10.0.tgz",
+            "integrity": "sha512-xlu1TZhTjnYtEWLnBhC4tqEafGwNcVi/J9Z1pzTtapDCDiTKTR5NS0FMmqJgKGaiaJG2Kidcv/rF6qSbid1KJA==",
             "dev": true,
             "requires": {
                 "@azure/arm-subscriptions": "^2.0.0",
@@ -20063,9 +20072,9 @@
             }
         },
         "vscode-azureextensionui": {
-            "version": "0.46.0",
-            "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.46.0.tgz",
-            "integrity": "sha512-UJkslUvo1oNvPNoyye5UKbWa9ESGoEE7jD1Q8bkHCDAfzRWiEOLe4kEIpQvMqFYEecWTSsVRsbDA1jpGlAWkqw==",
+            "version": "0.48.0",
+            "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.48.0.tgz",
+            "integrity": "sha512-8OAeuGZZambaRWB7SAJV9Nv6RpxfoHkEYVRBjICf9UH2g8D6A0viVerm7VEzM8gyFcBYpgqkqXXR9dHwwUgKQg==",
             "requires": {
                 "@azure/arm-resources": "^3.0.0",
                 "@azure/arm-resources-profile-2020-09-01-hybrid": "^1.0.0",
@@ -20080,9 +20089,17 @@
                 "html-to-text": "^5.1.1",
                 "open": "^8.0.4",
                 "semver": "^5.7.1",
+                "uuid": "^8.3.2",
                 "vscode-extension-telemetry": "^0.1.7",
                 "vscode-nls": "^4.1.1",
                 "vscode-tas-client": "^0.1.22"
+            },
+            "dependencies": {
+                "uuid": {
+                    "version": "8.3.2",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+                    "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+                }
             }
         },
         "vscode-extension-telemetry": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "publisher": "ms-azuretools",
     "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
     "engines": {
-        "vscode": "^1.48.0"
+        "vscode": "^1.57.0"
     },
     "repository": {
         "type": "git",
@@ -822,9 +822,9 @@
         "@types/gulp": "^4.0.6",
         "@types/keytar": "4.0.1",
         "@types/mocha": "^7.0.2",
-        "@types/node": "^12.0.0",
+        "@types/node": "^14.0.0",
         "@types/p-retry": "^3.0.1",
-        "@types/vscode": "1.48.0",
+        "@types/vscode": "1.57.0",
         "@types/winreg": "1.2.30",
         "@typescript-eslint/eslint-plugin": "^4.28.3",
         "copy-webpack-plugin": "^6.0.0",
@@ -837,7 +837,7 @@
         "ts-node": "^7.0.1",
         "typescript": "^4.3.5",
         "vsce": "^1.87.0",
-        "vscode-azureextensiondev": "^0.9.5",
+        "vscode-azureextensiondev": "^0.10.0",
         "vscode-test": "^1.5.2",
         "webpack": "^5.28.0",
         "webpack-cli": "^4.6.0"
@@ -854,7 +854,7 @@
         "mime": "^2.4.4",
         "open": "^8.0.4",
         "p-retry": "^4.2.0",
-        "vscode-azureextensionui": "^0.46.0",
+        "vscode-azureextensionui": "^0.48.0",
         "vscode-nls": "^4.1.1",
         "winreg": "^1.2.3"
     },

--- a/src/commands/blob/blobContainerActionHandlers.ts
+++ b/src/commands/blob/blobContainerActionHandlers.ts
@@ -49,7 +49,7 @@ async function openBlobContainerInStorageExplorer(_context: IActionContext, tree
     const resourceType = 'Azure.BlobContainer';
     const resourceName = treeItem.container.name;
 
-    await storageExplorerLauncher.openResource(accountId, treeItem.root.subscriptionId, resourceType, resourceName);
+    await storageExplorerLauncher.openResource(accountId, treeItem.subscription.subscriptionId, resourceType, resourceName);
 }
 
 export async function deleteBlobContainer(context: IActionContext, treeItem?: BlobContainerTreeItem): Promise<void> {

--- a/src/commands/fileShare/directoryActionHandlers.ts
+++ b/src/commands/fileShare/directoryActionHandlers.ts
@@ -3,13 +3,13 @@
  *  Licensed under the MIT License. See License.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { AzureParentTreeItem, IActionContext, registerCommand } from 'vscode-azureextensionui';
+import { AzExtParentTreeItem, IActionContext, registerCommand } from 'vscode-azureextensionui';
 import { DirectoryTreeItem } from '../../tree/fileShare/DirectoryTreeItem';
 import { IFileShareCreateChildContext } from '../../tree/fileShare/FileShareTreeItem';
 
 export function registerDirectoryActionHandlers(): void {
-    registerCommand("azureStorage.deleteDirectory", async (context: IActionContext, treeItem: AzureParentTreeItem) => await treeItem.deleteTreeItem(context));
-    registerCommand("azureStorage.createSubdirectory", async (context: IActionContext, treeItem: AzureParentTreeItem) => await treeItem.createChild(<IFileShareCreateChildContext>{ ...context, childType: DirectoryTreeItem.contextValue }));
+    registerCommand("azureStorage.deleteDirectory", async (context: IActionContext, treeItem: AzExtParentTreeItem) => await treeItem.deleteTreeItem(context));
+    registerCommand("azureStorage.createSubdirectory", async (context: IActionContext, treeItem: AzExtParentTreeItem) => await treeItem.createChild(<IFileShareCreateChildContext>{ ...context, childType: DirectoryTreeItem.contextValue }));
 
     // Note: azureStorage.createTextFile is registered in fileShareActionHandlers
 }

--- a/src/commands/fileShare/fileShareActionHandlers.ts
+++ b/src/commands/fileShare/fileShareActionHandlers.ts
@@ -24,7 +24,7 @@ export function registerFileShareActionHandlers(): void {
 
 async function openFileShareInStorageExplorer(_context: IActionContext, treeItem: FileShareTreeItem): Promise<void> {
     const accountId = treeItem.root.storageAccountId;
-    const subscriptionid = treeItem.root.subscriptionId;
+    const subscriptionid = treeItem.subscription.subscriptionId;
     const resourceType = 'Azure.FileShare';
     const resourceName = treeItem.shareName;
 

--- a/src/commands/queue/queueActionHandlers.ts
+++ b/src/commands/queue/queueActionHandlers.ts
@@ -18,7 +18,7 @@ async function openQueueInStorageExplorer(_context: IActionContext, treeItem: Qu
     const resourceType = "Azure.Queue";
     const resourceName = treeItem.queue.name;
 
-    await storageExplorerLauncher.openResource(accountId, treeItem.root.subscriptionId, resourceType, resourceName);
+    await storageExplorerLauncher.openResource(accountId, treeItem.subscription.subscriptionId, resourceType, resourceName);
 }
 
 export async function deleteQueue(context: IActionContext, treeItem?: QueueTreeItem): Promise<void> {

--- a/src/commands/selectStorageAccountNodeForCommand.ts
+++ b/src/commands/selectStorageAccountNodeForCommand.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
-import { AzureTreeItem, IActionContext } from "vscode-azureextensionui";
+import { AzExtTreeItem, IActionContext } from "vscode-azureextensionui";
 import { ext } from "../extensionVariables";
 import { AttachedStorageAccountTreeItem } from '../tree/AttachedStorageAccountTreeItem';
 import { BlobContainerTreeItem } from "../tree/blob/BlobContainerTreeItem";
@@ -19,7 +19,7 @@ import { localize } from '../utils/localize';
  *   4) anything else, then throw an internal error
  */
 export async function selectStorageAccountTreeItemForCommand(
-    treeItem: AzureTreeItem | undefined,
+    treeItem: AzExtTreeItem | undefined,
     context: ISelectStorageAccountContext,
     options: { mustBeWebsiteCapable: boolean, configureWebsite: boolean }
 ): Promise<StorageAccountTreeItem> {

--- a/src/commands/storageAccountActionHandlers.ts
+++ b/src/commands/storageAccountActionHandlers.ts
@@ -31,7 +31,7 @@ async function openStorageAccountInStorageExplorer(context: IActionContext, tree
 
     const accountId = treeItem.storageAccount.id;
 
-    await storageExplorerLauncher.openResource(accountId, treeItem.root.subscriptionId);
+    await storageExplorerLauncher.openResource(accountId, treeItem.subscription.subscriptionId);
 }
 
 export async function copyPrimaryKey(context: IActionContext, treeItem?: StorageAccountTreeItem): Promise<void> {

--- a/src/commands/table/tableActionHandlers.ts
+++ b/src/commands/table/tableActionHandlers.ts
@@ -18,7 +18,7 @@ async function openTableInStorageExplorer(_context: IActionContext, treeItem: Ta
     const resourceType = "Azure.Table";
     const resourceName = treeItem.tableName;
 
-    await storageExplorerLauncher.openResource(accountId, treeItem.root.subscriptionId, resourceType, resourceName);
+    await storageExplorerLauncher.openResource(accountId, treeItem.subscription.subscriptionId, resourceType, resourceName);
 }
 
 export async function deleteTable(context: IActionContext, treeItem?: TableTreeItem): Promise<void> {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@
 
 import * as vscode from 'vscode';
 import { commands } from 'vscode';
-import { AzExtTreeDataProvider, AzExtTreeItem, AzureTreeItem, AzureWizard, callWithTelemetryAndErrorHandling, createApiProvider, createAzExtOutputChannel, IActionContext, registerCommand, registerErrorHandler, registerReportIssueCommand, registerUIExtensionVariables } from 'vscode-azureextensionui';
+import { AzExtTreeDataProvider, AzExtTreeItem, AzureWizard, callWithTelemetryAndErrorHandling, createApiProvider, createAzExtOutputChannel, IActionContext, openInPortal, registerCommand, registerErrorHandler, registerReportIssueCommand, registerUIExtensionVariables } from 'vscode-azureextensionui';
 import { AzureExtensionApi, AzureExtensionApiProvider } from 'vscode-azureextensionui/api';
 import { AzureStorageFS } from './AzureStorageFS';
 import { revealTreeItem } from './commands/api/revealTreeItem';
@@ -95,16 +95,16 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
         });
         registerCommand('azureStorage.refresh', async (actionContext: IActionContext, treeItem?: AzExtTreeItem) => ext.tree.refresh(actionContext, treeItem));
         registerCommand('azureStorage.loadMore', async (actionContext: IActionContext, treeItem: AzExtTreeItem) => await ext.tree.loadMore(treeItem, actionContext));
-        registerCommand('azureStorage.copyUrl', (_actionContext: IActionContext, treeItem: AzureTreeItem & ICopyUrl) => treeItem.copyUrl());
+        registerCommand('azureStorage.copyUrl', (_actionContext: IActionContext, treeItem: AzExtTreeItem & ICopyUrl) => treeItem.copyUrl());
         registerCommand('azureStorage.selectSubscriptions', () => commands.executeCommand("azure-account.selectSubscriptions"));
-        registerCommand("azureStorage.openInPortal", async (actionContext: IActionContext, treeItem?: AzureTreeItem) => {
+        registerCommand("azureStorage.openInPortal", async (actionContext: IActionContext, treeItem?: AzExtTreeItem) => {
             if (!treeItem) {
                 treeItem = <StorageAccountTreeItem>await ext.tree.showTreeItemPicker(StorageAccountTreeItem.contextValue, actionContext);
             }
 
-            await treeItem.openInPortal();
+            await openInPortal(treeItem, treeItem.fullId);
         });
-        registerCommand("azureStorage.configureStaticWebsite", async (actionContext: IActionContext, treeItem?: AzureTreeItem) => {
+        registerCommand("azureStorage.configureStaticWebsite", async (actionContext: IActionContext, treeItem?: AzExtTreeItem) => {
             const accountTreeItem = await selectStorageAccountTreeItemForCommand(
                 treeItem,
                 actionContext,
@@ -114,7 +114,7 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
                 });
             await accountTreeItem.configureStaticWebsite(actionContext);
         });
-        registerCommand("azureStorage.disableStaticWebsite", async (actionContext: IActionContext, treeItem?: AzureTreeItem) => {
+        registerCommand("azureStorage.disableStaticWebsite", async (actionContext: IActionContext, treeItem?: AzExtTreeItem) => {
             const accountTreeItem = await selectStorageAccountTreeItemForCommand(
                 treeItem,
                 actionContext,
@@ -126,7 +126,7 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
         });
         registerCommand("azureStorage.createGpv2Account", createStorageAccount);
         registerCommand("azureStorage.createGpv2AccountAdvanced", createStorageAccountAdvanced);
-        registerCommand('azureStorage.browseStaticWebsite', async (actionContext: IActionContext, treeItem?: AzureTreeItem) => {
+        registerCommand('azureStorage.browseStaticWebsite', async (actionContext: IActionContext, treeItem?: AzExtTreeItem) => {
             const accountTreeItem = await selectStorageAccountTreeItemForCommand(
                 treeItem,
                 actionContext,

--- a/src/tree/AttachedStorageAccountTreeItem.ts
+++ b/src/tree/AttachedStorageAccountTreeItem.ts
@@ -8,7 +8,7 @@ import { AccountSASSignatureValues, generateAccountSASQueryParameters, StorageSh
 import * as azureStorageShare from '@azure/storage-file-share';
 import * as azureStorage from "azure-storage";
 import * as path from 'path';
-import { AzureParentTreeItem, AzureTreeItem } from 'vscode-azureextensionui';
+import { AzExtParentTreeItem, AzExtTreeItem } from 'vscode-azureextensionui';
 import { emulatorAccountName, emulatorConnectionString, emulatorKey, getResourcesPath } from '../constants';
 import { getPropertyFromConnectionString } from '../utils/getPropertyFromConnectionString';
 import { localize } from '../utils/localize';
@@ -20,7 +20,7 @@ import { QueueGroupTreeItem } from './queue/QueueGroupTreeItem';
 import { StorageAccountTreeItem, WebsiteHostingStatus } from './StorageAccountTreeItem';
 import { TableGroupTreeItem } from './table/TableGroupTreeItem';
 
-export class AttachedStorageAccountTreeItem extends AzureParentTreeItem {
+export class AttachedStorageAccountTreeItem extends AzExtParentTreeItem {
     public childTypeLabel: string = 'resource type';
     public autoSelectInTreeItemPicker: boolean = true;
     public static baseContextValue: string = `${StorageAccountTreeItem.contextValue}-attached`;
@@ -33,7 +33,7 @@ export class AttachedStorageAccountTreeItem extends AzureParentTreeItem {
     private _root: IStorageRoot;
 
     constructor(
-        parent: AzureParentTreeItem,
+        parent: AzExtParentTreeItem,
         public readonly connectionString: string,
         private readonly storageAccountName: string) {
         super(parent);
@@ -64,8 +64,8 @@ export class AttachedStorageAccountTreeItem extends AzureParentTreeItem {
     }
 
     // eslint-disable-next-line @typescript-eslint/require-await
-    public async loadMoreChildrenImpl(): Promise<AzureTreeItem<IStorageRoot>[]> {
-        const groupTreeItems: AzureTreeItem<IStorageRoot>[] = [this._blobContainerGroupTreeItem, this._queueGroupTreeItem];
+    public async loadMoreChildrenImpl(): Promise<AzExtTreeItem[]> {
+        const groupTreeItems: AzExtTreeItem[] = [this._blobContainerGroupTreeItem, this._queueGroupTreeItem];
 
         if (!this.root.isEmulated) {
             groupTreeItems.push(this._fileShareGroupTreeItem, this._tableGroupTreeItem);

--- a/src/tree/AttachedStorageAccountsTreeItem.ts
+++ b/src/tree/AttachedStorageAccountsTreeItem.ts
@@ -5,7 +5,7 @@
 
 import * as azureStorageBlob from '@azure/storage-blob';
 import { ThemeIcon } from 'vscode';
-import { AzExtParentTreeItem, AzExtTreeItem, AzureParentTreeItem, IActionContext, ISubscriptionContext, parseError, TreeItemIconPath } from "vscode-azureextensionui";
+import { AzExtParentTreeItem, AzExtTreeItem, IActionContext, ISubscriptionContext, parseError, TreeItemIconPath } from "vscode-azureextensionui";
 import { emulatorAccountName, emulatorConnectionString } from '../constants';
 import { ext } from '../extensionVariables';
 import { getPropertyFromConnectionString } from '../utils/getPropertyFromConnectionString';
@@ -19,7 +19,7 @@ interface IPersistedAccount {
     fullId: string;
 }
 
-export class AttachedStorageAccountsTreeItem extends AzureParentTreeItem {
+export class AttachedStorageAccountsTreeItem extends AzExtParentTreeItem {
     public readonly contextValue: string = 'attachedStorageAccounts';
     public readonly label: string = 'Attached Storage Accounts';
     public childTypeLabel: string = 'Account';

--- a/src/tree/IStorageRoot.ts
+++ b/src/tree/IStorageRoot.ts
@@ -8,9 +8,8 @@ import * as azureStorageBlob from "@azure/storage-blob";
 import { AccountSASSignatureValues } from "@azure/storage-blob";
 import * as azureStorageShare from "@azure/storage-file-share";
 import * as azureStorage from "azure-storage";
-import { ISubscriptionContext } from "vscode-azureextensionui";
 
-export interface IStorageRoot extends ISubscriptionContext {
+export interface IStorageRoot {
     storageAccountName: string;
     storageAccountId: string;
     isEmulated: boolean;

--- a/src/tree/blob/BlobContainerGroupTreeItem.ts
+++ b/src/tree/blob/BlobContainerGroupTreeItem.ts
@@ -6,7 +6,7 @@
 import * as azureStorageBlob from "@azure/storage-blob";
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { AzExtTreeItem, AzureParentTreeItem, GenericTreeItem, ICreateChildImplContext, parseError, UserCancelledError } from 'vscode-azureextensionui';
+import { AzExtParentTreeItem, AzExtTreeItem, GenericTreeItem, ICreateChildImplContext, parseError, UserCancelledError } from 'vscode-azureextensionui';
 import { getResourcesPath, maxPageSize } from "../../constants";
 import { createBlobContainerClient } from '../../utils/blobUtils';
 import { localize } from "../../utils/localize";
@@ -15,13 +15,14 @@ import { IStorageRoot } from "../IStorageRoot";
 import { StorageAccountTreeItem } from "../StorageAccountTreeItem";
 import { BlobContainerTreeItem } from "./BlobContainerTreeItem";
 
-export class BlobContainerGroupTreeItem extends AzureParentTreeItem<IStorageRoot> {
+export class BlobContainerGroupTreeItem extends AzExtParentTreeItem {
     private _continuationToken: string | undefined;
 
     public label: string = "Blob Containers";
     public readonly childTypeLabel: string = "Blob Container";
     public static contextValue: string = 'azureBlobContainerGroup';
     public contextValue: string = BlobContainerGroupTreeItem.contextValue;
+    public parent: StorageAccountTreeItem | AttachedStorageAccountTreeItem;
 
     public constructor(parent: StorageAccountTreeItem | AttachedStorageAccountTreeItem) {
         super(parent);
@@ -29,6 +30,10 @@ export class BlobContainerGroupTreeItem extends AzureParentTreeItem<IStorageRoot
             light: path.join(getResourcesPath(), 'light', 'AzureBlobContainer.svg'),
             dark: path.join(getResourcesPath(), 'dark', 'AzureBlobContainer.svg')
         };
+    }
+
+    public get root(): IStorageRoot {
+        return this.parent.root;
     }
 
     public async loadMoreChildrenImpl(clearCache: boolean): Promise<AzExtTreeItem[]> {

--- a/src/tree/blob/BlobContainerTreeItem.ts
+++ b/src/tree/blob/BlobContainerTreeItem.ts
@@ -9,7 +9,7 @@ import * as retry from 'p-retry';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { ProgressLocation, Uri } from 'vscode';
-import { AzExtTreeItem, AzureParentTreeItem, AzureTreeItem, DialogResponses, GenericTreeItem, IActionContext, ICreateChildImplContext, IParsedError, parseError, TelemetryProperties, UserCancelledError } from 'vscode-azureextensionui';
+import { AzExtParentTreeItem, AzExtTreeItem, DialogResponses, GenericTreeItem, IActionContext, ICreateChildImplContext, IParsedError, parseError, TelemetryProperties, UserCancelledError } from 'vscode-azureextensionui';
 import { AzureStorageFS } from '../../AzureStorageFS';
 import { createAzCopyLocalLocation, createAzCopyRemoteLocation } from '../../commands/azCopy/azCopyLocations';
 import { azCopyTransfer } from '../../commands/azCopy/azCopyTransfer';
@@ -23,7 +23,7 @@ import { localize } from '../../utils/localize';
 import { getWorkspaceSetting } from '../../utils/settingsUtils';
 import { getUploadingMessageWithSource, uploadLocalFolder } from '../../utils/uploadUtils';
 import { ICopyUrl } from '../ICopyUrl';
-import { IStorageRoot } from "../IStorageRoot";
+import { IStorageRoot } from '../IStorageRoot';
 import { StorageAccountTreeItem } from "../StorageAccountTreeItem";
 import { BlobContainerGroupTreeItem } from "./BlobContainerGroupTreeItem";
 import { BlobDirectoryTreeItem } from "./BlobDirectoryTreeItem";
@@ -34,15 +34,20 @@ export enum ChildType {
     uploadedBlob
 }
 
-export class BlobContainerTreeItem extends AzureParentTreeItem<IStorageRoot> implements ICopyUrl {
+export class BlobContainerTreeItem extends AzExtParentTreeItem implements ICopyUrl {
     private _continuationToken: string | undefined;
     private _websiteHostingEnabled: boolean;
     private _openInFileExplorerString: string = 'Open in File Explorer...';
+    public parent: BlobContainerGroupTreeItem;
 
     private constructor(
         parent: BlobContainerGroupTreeItem,
         public readonly container: azureStorageBlob.ContainerItem) {
         super(parent);
+    }
+
+    public get root(): IStorageRoot {
+        return this.parent.root;
     }
 
     public static async createBlobContainerTreeItem(parent: BlobContainerGroupTreeItem, container: azureStorageBlob.ContainerItem): Promise<BlobContainerTreeItem> {
@@ -272,7 +277,7 @@ export class BlobContainerTreeItem extends AzureParentTreeItem<IStorageRoot> imp
         return this.root.primaryEndpoints && this.root.primaryEndpoints.web;
     }
 
-    public getStorageAccountTreeItem(treeItem: AzureTreeItem): StorageAccountTreeItem {
+    public getStorageAccountTreeItem(treeItem: AzExtTreeItem): StorageAccountTreeItem {
         if (!(treeItem instanceof BlobContainerTreeItem)) {
             throw new Error(`Unexpected treeItem type: ${treeItem.contextValue}`);
         }

--- a/src/tree/blob/BlobDirectoryTreeItem.ts
+++ b/src/tree/blob/BlobDirectoryTreeItem.ts
@@ -6,7 +6,7 @@
 import * as azureStorageBlob from "@azure/storage-blob";
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { AzExtTreeItem, AzureParentTreeItem, DialogResponses, IActionContext, ICreateChildImplContext, parseError, TreeItemIconPath } from "vscode-azureextensionui";
+import { AzExtParentTreeItem, AzExtTreeItem, DialogResponses, IActionContext, ICreateChildImplContext, parseError, TreeItemIconPath } from "vscode-azureextensionui";
 import { AzureStorageFS } from "../../AzureStorageFS";
 import { ext } from "../../extensionVariables";
 import { createBlobClient, createChildAsNewBlockBlob, IBlobContainerCreateChildContext, loadMoreBlobChildren } from '../../utils/blobUtils';
@@ -16,9 +16,10 @@ import { IStorageRoot } from "../IStorageRoot";
 import { BlobContainerTreeItem } from "./BlobContainerTreeItem";
 import { BlobTreeItem, ISuppressMessageContext } from "./BlobTreeItem";
 
-export class BlobDirectoryTreeItem extends AzureParentTreeItem<IStorageRoot> implements ICopyUrl {
+export class BlobDirectoryTreeItem extends AzExtParentTreeItem implements ICopyUrl {
     public static contextValue: string = 'azureBlobDirectory';
     public contextValue: string = BlobDirectoryTreeItem.contextValue;
+    public parent: BlobContainerTreeItem | BlobDirectoryTreeItem;
 
     /**
      * The name (and only the name) of the directory
@@ -40,6 +41,10 @@ export class BlobDirectoryTreeItem extends AzureParentTreeItem<IStorageRoot> imp
 
         this.dirPath = dirPath;
         this.dirName = path.basename(dirPath);
+    }
+
+    public get root(): IStorageRoot {
+        return this.parent.root;
     }
 
     public get label(): string {

--- a/src/tree/fileShare/DirectoryTreeItem.ts
+++ b/src/tree/fileShare/DirectoryTreeItem.ts
@@ -7,19 +7,20 @@ import * as azureStorageShare from '@azure/storage-file-share';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { MessageItem, window } from 'vscode';
-import { AzExtTreeItem, AzureParentTreeItem, DialogResponses, IActionContext, ICreateChildImplContext, TreeItemIconPath, UserCancelledError } from 'vscode-azureextensionui';
+import { AzExtParentTreeItem, AzExtTreeItem, DialogResponses, IActionContext, ICreateChildImplContext, TreeItemIconPath, UserCancelledError } from 'vscode-azureextensionui';
 import { AzureStorageFS } from "../../AzureStorageFS";
 import { ext } from "../../extensionVariables";
 import { askAndCreateChildDirectory, deleteDirectoryAndContents, listFilesInDirectory } from '../../utils/directoryUtils';
 import { askAndCreateEmptyTextFile, createDirectoryClient } from '../../utils/fileUtils';
 import { ICopyUrl } from '../ICopyUrl';
-import { IStorageRoot } from "../IStorageRoot";
-import { IFileShareCreateChildContext } from "./FileShareTreeItem";
+import { IStorageRoot } from '../IStorageRoot';
+import { FileShareTreeItem, IFileShareCreateChildContext } from "./FileShareTreeItem";
 import { FileTreeItem } from './FileTreeItem';
 
-export class DirectoryTreeItem extends AzureParentTreeItem<IStorageRoot> implements ICopyUrl {
+export class DirectoryTreeItem extends AzExtParentTreeItem implements ICopyUrl {
+    public parent: FileShareTreeItem | DirectoryTreeItem;
     constructor(
-        parent: AzureParentTreeItem,
+        parent: FileShareTreeItem | DirectoryTreeItem,
         public readonly parentPath: string,
         public readonly directoryName: string, // directoryName should not include parent path
         public readonly shareName: string) {
@@ -30,6 +31,10 @@ export class DirectoryTreeItem extends AzureParentTreeItem<IStorageRoot> impleme
     public label: string = this.directoryName;
     public static contextValue: string = 'azureFileShareDirectory';
     public contextValue: string = DirectoryTreeItem.contextValue;
+
+    public get root(): IStorageRoot {
+        return this.parent.root;
+    }
 
     public get iconPath(): TreeItemIconPath {
         return new vscode.ThemeIcon('folder');

--- a/src/tree/fileShare/FileShareGroupTreeItem.ts
+++ b/src/tree/fileShare/FileShareGroupTreeItem.ts
@@ -6,10 +6,12 @@
 import * as azureStorageShare from '@azure/storage-file-share';
 import * as path from 'path';
 import { ProgressLocation, window } from 'vscode';
-import { AzureParentTreeItem, ICreateChildImplContext, parseError, UserCancelledError } from 'vscode-azureextensionui';
+import { AzExtParentTreeItem, ICreateChildImplContext, parseError, UserCancelledError } from 'vscode-azureextensionui';
 import { getResourcesPath, maxPageSize } from "../../constants";
 import { localize } from '../../utils/localize';
-import { IStorageRoot } from "../IStorageRoot";
+import { AttachedStorageAccountTreeItem } from '../AttachedStorageAccountTreeItem';
+import { IStorageRoot } from '../IStorageRoot';
+import { StorageAccountTreeItem } from '../StorageAccountTreeItem';
 import { DirectoryTreeItem } from './DirectoryTreeItem';
 import { FileShareTreeItem } from './FileShareTreeItem';
 import { FileTreeItem } from './FileTreeItem';
@@ -17,20 +19,25 @@ import { FileTreeItem } from './FileTreeItem';
 const minQuotaGB = 1;
 const maxQuotaGB = 5120;
 
-export class FileShareGroupTreeItem extends AzureParentTreeItem<IStorageRoot> {
+export class FileShareGroupTreeItem extends AzExtParentTreeItem {
     private _continuationToken: string | undefined;
 
     public label: string = "File Shares";
     public readonly childTypeLabel: string = "File Share";
     public static contextValue: string = 'azureFileShareGroup';
     public contextValue: string = FileShareGroupTreeItem.contextValue;
+    public parent: StorageAccountTreeItem | AttachedStorageAccountTreeItem;
 
-    constructor(parent: AzureParentTreeItem) {
+    public constructor(parent: StorageAccountTreeItem | AttachedStorageAccountTreeItem) {
         super(parent);
         this.iconPath = {
             light: path.join(getResourcesPath(), 'light', 'AzureFileShare.svg'),
             dark: path.join(getResourcesPath(), 'dark', 'AzureFileShare.svg')
         };
+    }
+
+    public get root(): IStorageRoot {
+        return this.parent.root;
     }
 
     async loadMoreChildrenImpl(clearCache: boolean): Promise<FileShareTreeItem[]> {

--- a/src/tree/fileShare/FileShareTreeItem.ts
+++ b/src/tree/fileShare/FileShareTreeItem.ts
@@ -7,7 +7,7 @@ import { ILocalLocation, IRemoteSasLocation } from '@azure-tools/azcopy-node';
 import * as azureStorageShare from '@azure/storage-file-share';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { AzExtTreeItem, AzureParentTreeItem, DialogResponses, GenericTreeItem, IActionContext, ICreateChildImplContext, UserCancelledError } from 'vscode-azureextensionui';
+import { AzExtParentTreeItem, AzExtTreeItem, DialogResponses, GenericTreeItem, IActionContext, ICreateChildImplContext, UserCancelledError } from 'vscode-azureextensionui';
 import { AzureStorageFS } from "../../AzureStorageFS";
 import { createAzCopyLocalLocation, createAzCopyRemoteLocation } from '../../commands/azCopy/azCopyLocations';
 import { azCopyTransfer } from '../../commands/azCopy/azCopyTransfer';
@@ -19,22 +19,28 @@ import { askAndCreateChildDirectory, doesDirectoryExist, listFilesInDirectory } 
 import { askAndCreateEmptyTextFile, createDirectoryClient, createShareClient } from '../../utils/fileUtils';
 import { getUploadingMessageWithSource } from '../../utils/uploadUtils';
 import { ICopyUrl } from '../ICopyUrl';
-import { IStorageRoot } from "../IStorageRoot";
+import { IStorageRoot } from '../IStorageRoot';
 import { DirectoryTreeItem } from './DirectoryTreeItem';
+import { FileShareGroupTreeItem } from './FileShareGroupTreeItem';
 import { FileTreeItem } from './FileTreeItem';
 
-export class FileShareTreeItem extends AzureParentTreeItem<IStorageRoot> implements ICopyUrl {
+export class FileShareTreeItem extends AzExtParentTreeItem implements ICopyUrl {
+    public parent: FileShareGroupTreeItem;
     private _continuationToken: string | undefined;
     private _openInFileExplorerString: string = 'Open in File Explorer...';
 
     constructor(
-        parent: AzureParentTreeItem,
+        parent: FileShareGroupTreeItem,
         public readonly shareName: string) {
         super(parent);
         this.iconPath = {
             light: path.join(getResourcesPath(), 'light', 'AzureFileShare.svg'),
             dark: path.join(getResourcesPath(), 'dark', 'AzureFileShare.svg')
         };
+    }
+
+    public get root(): IStorageRoot {
+        return this.parent.root;
     }
 
     public label: string = this.shareName;

--- a/src/tree/fileShare/FileTreeItem.ts
+++ b/src/tree/fileShare/FileTreeItem.ts
@@ -6,17 +6,19 @@
 import * as azureStorageShare from '@azure/storage-file-share';
 import * as vscode from 'vscode';
 import { MessageItem, window } from 'vscode';
-import { AzureParentTreeItem, AzureTreeItem, DialogResponses, IActionContext, TreeItemIconPath, UserCancelledError } from 'vscode-azureextensionui';
+import { AzExtTreeItem, DialogResponses, IActionContext, TreeItemIconPath, UserCancelledError } from 'vscode-azureextensionui';
 import { AzureStorageFS } from "../../AzureStorageFS";
 import { ext } from "../../extensionVariables";
 import { createFileClient, deleteFile } from '../../utils/fileUtils';
 import { ICopyUrl } from '../ICopyUrl';
-import { IStorageRoot } from "../IStorageRoot";
-import { IDirectoryDeleteContext } from "./DirectoryTreeItem";
+import { IStorageRoot } from '../IStorageRoot';
+import { DirectoryTreeItem, IDirectoryDeleteContext } from "./DirectoryTreeItem";
+import { FileShareTreeItem } from './FileShareTreeItem';
 
-export class FileTreeItem extends AzureTreeItem<IStorageRoot> implements ICopyUrl {
+export class FileTreeItem extends AzExtTreeItem implements ICopyUrl {
+    public parent: FileShareTreeItem | DirectoryTreeItem;
     constructor(
-        parent: AzureParentTreeItem,
+        parent: FileShareTreeItem | DirectoryTreeItem,
         public readonly fileName: string,
         public readonly directoryPath: string,
         public readonly shareName: string) {
@@ -27,6 +29,10 @@ export class FileTreeItem extends AzureTreeItem<IStorageRoot> implements ICopyUr
     public label: string = this.fileName;
     public static contextValue: string = 'azureFile';
     public contextValue: string = FileTreeItem.contextValue;
+
+    public get root(): IStorageRoot {
+        return this.parent.root;
+    }
 
     public get iconPath(): TreeItemIconPath {
         return new vscode.ThemeIcon('file');

--- a/src/tree/queue/QueueGroupTreeItem.ts
+++ b/src/tree/queue/QueueGroupTreeItem.ts
@@ -6,7 +6,7 @@
 import * as azureStorage from "azure-storage";
 import * as path from 'path';
 import { ProgressLocation, window } from 'vscode';
-import { AzExtTreeItem, AzureParentTreeItem, GenericTreeItem, ICreateChildImplContext, parseError, UserCancelledError } from 'vscode-azureextensionui';
+import { AzExtParentTreeItem, AzExtTreeItem, GenericTreeItem, ICreateChildImplContext, parseError, UserCancelledError } from 'vscode-azureextensionui';
 import { getResourcesPath, maxPageSize } from "../../constants";
 import { localize } from "../../utils/localize";
 import { AttachedStorageAccountTreeItem } from "../AttachedStorageAccountTreeItem";
@@ -14,13 +14,14 @@ import { IStorageRoot } from "../IStorageRoot";
 import { StorageAccountTreeItem } from "../StorageAccountTreeItem";
 import { QueueTreeItem } from './QueueTreeItem';
 
-export class QueueGroupTreeItem extends AzureParentTreeItem<IStorageRoot> {
+export class QueueGroupTreeItem extends AzExtParentTreeItem {
     private _continuationToken: azureStorage.common.ContinuationToken | undefined;
 
     public label: string = "Queues";
     public readonly childTypeLabel: string = "Queue";
     public static contextValue: string = 'azureQueueGroup';
     public contextValue: string = QueueGroupTreeItem.contextValue;
+    public parent: StorageAccountTreeItem | AttachedStorageAccountTreeItem;
 
     public constructor(parent: StorageAccountTreeItem | AttachedStorageAccountTreeItem) {
         super(parent);
@@ -28,6 +29,10 @@ export class QueueGroupTreeItem extends AzureParentTreeItem<IStorageRoot> {
             light: path.join(getResourcesPath(), 'light', 'AzureQueue.svg'),
             dark: path.join(getResourcesPath(), 'dark', 'AzureQueue.svg')
         };
+    }
+
+    public get root(): IStorageRoot {
+        return this.parent.root;
     }
 
     async loadMoreChildrenImpl(clearCache: boolean): Promise<AzExtTreeItem[]> {

--- a/src/tree/queue/QueueTreeItem.ts
+++ b/src/tree/queue/QueueTreeItem.ts
@@ -5,19 +5,25 @@
 
 import * as azureStorage from "azure-storage";
 import * as path from 'path';
-import { AzureParentTreeItem, AzureTreeItem, DialogResponses, IActionContext, UserCancelledError } from 'vscode-azureextensionui';
+import { AzExtTreeItem, DialogResponses, IActionContext, UserCancelledError } from 'vscode-azureextensionui';
 import { getResourcesPath } from "../../constants";
 import { IStorageRoot } from "../IStorageRoot";
+import { QueueGroupTreeItem } from "./QueueGroupTreeItem";
 
-export class QueueTreeItem extends AzureTreeItem<IStorageRoot> {
+export class QueueTreeItem extends AzExtTreeItem {
+    public parent: QueueGroupTreeItem;
     constructor(
-        parent: AzureParentTreeItem,
+        parent: QueueGroupTreeItem,
         public readonly queue: azureStorage.QueueService.QueueResult) {
         super(parent);
         this.iconPath = {
             light: path.join(getResourcesPath(), 'light', 'AzureQueue.svg'),
             dark: path.join(getResourcesPath(), 'dark', 'AzureQueue.svg')
         };
+    }
+
+    public get root(): IStorageRoot {
+        return this.parent.root;
     }
 
     public label: string = this.queue.name;

--- a/src/tree/table/TableGroupTreeItem.ts
+++ b/src/tree/table/TableGroupTreeItem.ts
@@ -6,27 +6,34 @@
 import * as azureStorage from "azure-storage";
 import * as path from 'path';
 import { ProgressLocation, window } from 'vscode';
-import { AzureParentTreeItem, ICreateChildImplContext, parseError, UserCancelledError } from 'vscode-azureextensionui';
+import { AzExtParentTreeItem, ICreateChildImplContext, parseError, UserCancelledError } from 'vscode-azureextensionui';
 import { getResourcesPath, maxPageSize } from "../../constants";
 import { localize } from "../../utils/localize";
 import { nonNull } from "../../utils/storageWrappers";
+import { AttachedStorageAccountTreeItem } from "../AttachedStorageAccountTreeItem";
 import { IStorageRoot } from "../IStorageRoot";
+import { StorageAccountTreeItem } from "../StorageAccountTreeItem";
 import { TableTreeItem } from './TableTreeItem';
 
-export class TableGroupTreeItem extends AzureParentTreeItem<IStorageRoot> {
+export class TableGroupTreeItem extends AzExtParentTreeItem {
     private _continuationToken: azureStorage.TableService.ListTablesContinuationToken | undefined;
 
     public label: string = "Tables";
     public readonly childTypeLabel: string = "Table";
     public static contextValue: string = 'azureTableGroup';
     public contextValue: string = TableGroupTreeItem.contextValue;
+    public parent: StorageAccountTreeItem | AttachedStorageAccountTreeItem;
 
-    constructor(parent: AzureParentTreeItem) {
+    public constructor(parent: StorageAccountTreeItem | AttachedStorageAccountTreeItem) {
         super(parent);
         this.iconPath = {
             light: path.join(getResourcesPath(), 'light', 'AzureTable.svg'),
             dark: path.join(getResourcesPath(), 'dark', 'AzureTable.svg')
         };
+    }
+
+    public get root(): IStorageRoot {
+        return this.parent.root;
     }
 
     async loadMoreChildrenImpl(clearCache: boolean): Promise<TableTreeItem[]> {

--- a/src/tree/table/TableTreeItem.ts
+++ b/src/tree/table/TableTreeItem.ts
@@ -4,19 +4,25 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as path from 'path';
-import { AzureParentTreeItem, AzureTreeItem, DialogResponses, IActionContext, UserCancelledError } from 'vscode-azureextensionui';
+import { AzExtTreeItem, DialogResponses, IActionContext, UserCancelledError } from 'vscode-azureextensionui';
 import { getResourcesPath } from '../../constants';
-import { IStorageRoot } from "../IStorageRoot";
+import { IStorageRoot } from '../IStorageRoot';
+import { TableGroupTreeItem } from './TableGroupTreeItem';
 
-export class TableTreeItem extends AzureTreeItem<IStorageRoot> {
+export class TableTreeItem extends AzExtTreeItem {
+    public parent: TableGroupTreeItem;
     constructor(
-        parent: AzureParentTreeItem,
+        parent: TableGroupTreeItem,
         public readonly tableName: string) {
         super(parent);
         this.iconPath = {
             light: path.join(getResourcesPath(), 'light', 'AzureTable.svg'),
             dark: path.join(getResourcesPath(), 'dark', 'AzureTable.svg')
         };
+    }
+
+    public get root(): IStorageRoot {
+        return this.parent.root;
     }
 
     public label: string = this.tableName;

--- a/src/utils/azureClients.ts
+++ b/src/utils/azureClients.ts
@@ -4,13 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { StorageManagementClient } from '@azure/arm-storage';
-import { createAzureClient, ISubscriptionContext } from 'vscode-azureextensionui';
+import { AzExtClientContext, createAzureClient, parseClientContext } from 'vscode-azureextensionui';
 
 // Lazy-load @azure packages to improve startup performance.
 // NOTE: The client is the only import that matters, the rest of the types disappear when compiled to JavaScript
 
-export async function createStorageClient<T extends ISubscriptionContext>(context: T): Promise<StorageManagementClient> {
-    if (context.isCustomCloud) {
+export async function createStorageClient(context: AzExtClientContext): Promise<StorageManagementClient> {
+    if (parseClientContext(context).isCustomCloud) {
         // set API version for Azure Stack
         process.env.AZCOPY_DEFAULT_SERVICE_API_VERSION = "2019-02-02";
         return <StorageManagementClient><unknown>createAzureClient(context, (await import('@azure/arm-storage-profile-2020-09-01-hybrid')).StorageManagementClient);

--- a/src/utils/directoryUtils.ts
+++ b/src/utils/directoryUtils.ts
@@ -6,16 +6,16 @@
 import * as azureStorageShare from "@azure/storage-file-share";
 import * as path from "path";
 import { ProgressLocation, window } from "vscode";
-import { AzureParentTreeItem, ICreateChildImplContext } from "vscode-azureextensionui";
+import { ICreateChildImplContext } from "vscode-azureextensionui";
 import { maxPageSize } from "../constants";
 import { ext } from "../extensionVariables";
 import { DirectoryTreeItem } from "../tree/fileShare/DirectoryTreeItem";
-import { IFileShareCreateChildContext } from "../tree/fileShare/FileShareTreeItem";
+import { FileShareTreeItem, IFileShareCreateChildContext } from "../tree/fileShare/FileShareTreeItem";
 import { IStorageRoot } from "../tree/IStorageRoot";
 import { createDirectoryClient, deleteFile, getFileOrDirectoryName } from "./fileUtils";
 
 // Supports both file share and directory parents
-export async function askAndCreateChildDirectory(parent: AzureParentTreeItem<IStorageRoot>, parentPath: string, shareName: string, context: ICreateChildImplContext & IFileShareCreateChildContext): Promise<DirectoryTreeItem> {
+export async function askAndCreateChildDirectory(parent: FileShareTreeItem | DirectoryTreeItem, parentPath: string, shareName: string, context: ICreateChildImplContext & IFileShareCreateChildContext): Promise<DirectoryTreeItem> {
     const dirName: string = context.childName || await getFileOrDirectoryName(context, parent, parentPath, shareName);
     return await window.withProgress({ location: ProgressLocation.Window }, async (progress) => {
         context.showCreatingTreeItem(dirName);
@@ -75,7 +75,7 @@ export async function deleteDirectoryAndContents(directory: string, shareName: s
     ext.outputChannel.appendLog(`Deleted directory "${directory}"`);
 }
 
-export async function doesDirectoryExist(parent: AzureParentTreeItem<IStorageRoot>, directoryPath: string, shareName: string): Promise<boolean> {
+export async function doesDirectoryExist(parent: FileShareTreeItem | DirectoryTreeItem, directoryPath: string, shareName: string): Promise<boolean> {
     const directoryClient: azureStorageShare.ShareDirectoryClient = createDirectoryClient(parent.root, shareName, directoryPath);
     try {
         await directoryClient.getProperties();

--- a/src/utils/fileUtils.ts
+++ b/src/utils/fileUtils.ts
@@ -7,8 +7,9 @@ import * as azureStorageShare from '@azure/storage-file-share';
 import * as mime from 'mime';
 import { posix } from 'path';
 import { ProgressLocation, window } from "vscode";
-import { AzureParentTreeItem, IActionContext, ICreateChildImplContext } from "vscode-azureextensionui";
-import { IFileShareCreateChildContext } from "../tree/fileShare/FileShareTreeItem";
+import { IActionContext, ICreateChildImplContext } from "vscode-azureextensionui";
+import { DirectoryTreeItem } from '../tree/fileShare/DirectoryTreeItem';
+import { FileShareTreeItem, IFileShareCreateChildContext } from "../tree/fileShare/FileShareTreeItem";
 import { FileTreeItem } from "../tree/fileShare/FileTreeItem";
 import { IStorageRoot } from "../tree/IStorageRoot";
 import { doesDirectoryExist } from './directoryUtils';
@@ -30,7 +31,7 @@ export function createFileClient(root: IStorageRoot, shareName: string, director
     return directoryClient.getFileClient(fileName);
 }
 
-export async function askAndCreateEmptyTextFile(parent: AzureParentTreeItem<IStorageRoot>, directoryPath: string, shareName: string, context: ICreateChildImplContext & IFileShareCreateChildContext): Promise<FileTreeItem> {
+export async function askAndCreateEmptyTextFile(parent: FileShareTreeItem | DirectoryTreeItem, directoryPath: string, shareName: string, context: ICreateChildImplContext & IFileShareCreateChildContext): Promise<FileTreeItem> {
     const fileName: string = context.childName || await getFileOrDirectoryName(context, parent, directoryPath, shareName);
     return await window.withProgress({ location: ProgressLocation.Window }, async (progress) => {
         context.showCreatingTreeItem(fileName);
@@ -40,7 +41,7 @@ export async function askAndCreateEmptyTextFile(parent: AzureParentTreeItem<ISto
     });
 }
 
-export async function getFileOrDirectoryName(context: IActionContext, parent: AzureParentTreeItem<IStorageRoot>, directoryPath: string, shareName: string, value?: string): Promise<string> {
+export async function getFileOrDirectoryName(context: IActionContext, parent: FileShareTreeItem | DirectoryTreeItem, directoryPath: string, shareName: string, value?: string): Promise<string> {
     return await context.ui.showInputBox({
         value,
         placeHolder: localize('enterName', 'Enter a name for the new resource'),
@@ -56,7 +57,7 @@ export async function getFileOrDirectoryName(context: IActionContext, parent: Az
     });
 }
 
-export async function doesFileExist(fileName: string, parent: AzureParentTreeItem<IStorageRoot>, directoryPath: string, shareName: string): Promise<boolean> {
+export async function doesFileExist(fileName: string, parent: FileShareTreeItem | DirectoryTreeItem, directoryPath: string, shareName: string): Promise<boolean> {
     const fileService: azureStorageShare.ShareFileClient = createFileClient(parent.root, shareName, directoryPath, fileName);
     try {
         await fileService.getProperties();

--- a/test/nightly/deploy.test.ts
+++ b/test/nightly/deploy.test.ts
@@ -33,7 +33,7 @@ suite('Deploy', function (this: Mocha.Suite): void {
             });
             const createdAccount: StorageAccount = await webSiteClient.storageAccounts.getProperties(resourceName, resourceName);
             const webUrl: string | undefined = (<StorageAccountTreeItem>await ext.tree.findTreeItem(<string>createdAccount.id, context)).root.primaryEndpoints?.web;
-            const client: ServiceClient = await createGenericClient();
+            const client: ServiceClient = await createGenericClient(context, undefined);
             await validateWebSite(webUrl, client, 60 * 1000, 1000);
         });
     })

--- a/test/nightly/global.resource.test.ts
+++ b/test/nightly/global.resource.test.ts
@@ -6,7 +6,7 @@
 import { ResourceManagementClient } from '@azure/arm-resources';
 import { StorageManagementClient } from '@azure/arm-storage';
 import * as vscode from 'vscode';
-import { TestAzureAccount } from 'vscode-azureextensiondev';
+import { createTestActionContext, TestAzureAccount } from 'vscode-azureextensiondev';
 import { AzExtTreeDataProvider, AzureAccountTreeItem, createAzureClient, ext } from '../../extension.bundle';
 import { longRunningTestsEnabled } from '../global.test';
 
@@ -21,7 +21,7 @@ suiteSetup(async function (this: Mocha.Context): Promise<void> {
         await testAccount.signIn();
         ext.azureAccountTreeItem = new AzureAccountTreeItem(testAccount);
         ext.tree = new AzExtTreeDataProvider(ext.azureAccountTreeItem, 'azureStorage.loadMore');
-        webSiteClient = createAzureClient(testAccount.getSubscriptionContext(), StorageManagementClient);
+        webSiteClient = createAzureClient([await createTestActionContext(), testAccount.getSubscriptionContext()], StorageManagementClient);
     }
 });
 
@@ -36,7 +36,7 @@ suiteTeardown(async function (this: Mocha.Context): Promise<void> {
 });
 
 export async function beginDeleteResourceGroup(resourceGroup: string): Promise<void> {
-    const client: ResourceManagementClient = createAzureClient(testAccount.getSubscriptionContext(), ResourceManagementClient);
+    const client: ResourceManagementClient = createAzureClient([await createTestActionContext(), testAccount.getSubscriptionContext()], ResourceManagementClient);
     if ((await client.resourceGroups.checkExistence(resourceGroup)).body) {
         console.log(`Started delete of resource group "${resourceGroup}"...`);
         await client.resourceGroups.beginDeleteMethod(resourceGroup);


### PR DESCRIPTION
See microsoft/vscode-azuretools#984 for more info

Also, I had to take into account breaking changes from UI v0.47.0 - related to https://github.com/microsoft/vscode-azuretools/pull/963. I kind of forgot how heavily this repo used `treeItem.root` from `AzureTreeItem` so I did a half-ish thing to keep using `root` but not reference the `AzureTreeItem` classes that were removed 