### PR TITLE
Create BlockBlob premium accounts for EdgeZones

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
                 "mime": "^2.4.4",
                 "open": "^8.0.4",
                 "p-retry": "^4.2.0",
-                "vscode-azureextensionui": "^0.49.0",
+                "vscode-azureextensionui": "file:../vscode-azuretools/ui/vscode-azureextensionui-0.49.2.tgz",
                 "vscode-nls": "^4.1.1",
                 "winreg": "^1.2.3"
             },
@@ -10782,9 +10782,10 @@
             }
         },
         "node_modules/vscode-azureextensionui": {
-            "version": "0.49.0",
-            "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.49.0.tgz",
-            "integrity": "sha512-CuC8k2hDNLilfmDKoQy7DxlM6PDdum1Wdqk/lmASFeYD9JC9dk4y1bpjdyBPKFfcuMnhN6x7Sm/NJEyYH8oaXg==",
+            "version": "0.49.2",
+            "resolved": "file:../vscode-azuretools/ui/vscode-azureextensionui-0.49.2.tgz",
+            "integrity": "sha512-kcKrqBpzxeU5KTIYqOU2/D0Y+mI5phw0GAYwRSRmSrjems3JDrFxHpDGp/aBTKZrU9fnML/tbgb0Thg63x86Cw==",
+            "license": "MIT",
             "dependencies": {
                 "@azure/arm-resources": "^4.0.0",
                 "@azure/arm-resources-profile-2020-09-01-hybrid": "^1.0.0",
@@ -10799,7 +10800,7 @@
                 "open": "^8.0.4",
                 "semver": "^5.7.1",
                 "uuid": "^8.3.2",
-                "vscode-extension-telemetry": "^0.3.1",
+                "vscode-extension-telemetry": "^0.4.3",
                 "vscode-nls": "^4.1.1",
                 "vscode-tas-client": "^0.1.22"
             }
@@ -10834,11 +10835,12 @@
             }
         },
         "node_modules/vscode-extension-telemetry": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.3.2.tgz",
-            "integrity": "sha512-zVvd5MNtMP4x7seq/yFeD+yrXIX5pXz6YaohI1pgDXCTEDs6yn377KisHXY2we8gw+u0gYug75+5QfewrCQ2cw==",
+            "version": "0.4.5",
+            "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.4.5.tgz",
+            "integrity": "sha512-YhPiPcelqM5xyYWmD46jIcsxLYWkPZhAxlBkzqmpa218fMtTT17ERdOZVCXcs1S5AjvDHlq43yCgi8TaVQjjEg==",
+            "deprecated": "This package has been renamed to @vscode/extension-telemetry, please update to the new name",
             "engines": {
-                "vscode": "^1.5.0"
+                "vscode": "^1.60.0"
             }
         },
         "node_modules/vscode-nls": {
@@ -20055,9 +20057,8 @@
             }
         },
         "vscode-azureextensionui": {
-            "version": "0.49.0",
-            "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.49.0.tgz",
-            "integrity": "sha512-CuC8k2hDNLilfmDKoQy7DxlM6PDdum1Wdqk/lmASFeYD9JC9dk4y1bpjdyBPKFfcuMnhN6x7Sm/NJEyYH8oaXg==",
+            "version": "file:../vscode-azuretools/ui/vscode-azureextensionui-0.49.2.tgz",
+            "integrity": "sha512-kcKrqBpzxeU5KTIYqOU2/D0Y+mI5phw0GAYwRSRmSrjems3JDrFxHpDGp/aBTKZrU9fnML/tbgb0Thg63x86Cw==",
             "requires": {
                 "@azure/arm-resources": "^4.0.0",
                 "@azure/arm-resources-profile-2020-09-01-hybrid": "^1.0.0",
@@ -20072,7 +20073,7 @@
                 "open": "^8.0.4",
                 "semver": "^5.7.1",
                 "uuid": "^8.3.2",
-                "vscode-extension-telemetry": "^0.3.1",
+                "vscode-extension-telemetry": "^0.4.3",
                 "vscode-nls": "^4.1.1",
                 "vscode-tas-client": "^0.1.22"
             },
@@ -20106,9 +20107,9 @@
             }
         },
         "vscode-extension-telemetry": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.3.2.tgz",
-            "integrity": "sha512-zVvd5MNtMP4x7seq/yFeD+yrXIX5pXz6YaohI1pgDXCTEDs6yn377KisHXY2we8gw+u0gYug75+5QfewrCQ2cw=="
+            "version": "0.4.5",
+            "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.4.5.tgz",
+            "integrity": "sha512-YhPiPcelqM5xyYWmD46jIcsxLYWkPZhAxlBkzqmpa218fMtTT17ERdOZVCXcs1S5AjvDHlq43yCgi8TaVQjjEg=="
         },
         "vscode-nls": {
             "version": "4.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
                 "mime": "^2.4.4",
                 "open": "^8.0.4",
                 "p-retry": "^4.2.0",
-                "vscode-azureextensionui": "file:../vscode-azuretools/ui/vscode-azureextensionui-0.49.2.tgz",
+                "vscode-azureextensionui": "^0.49.3",
                 "vscode-nls": "^4.1.1",
                 "winreg": "^1.2.3"
             },
@@ -10782,10 +10782,9 @@
             }
         },
         "node_modules/vscode-azureextensionui": {
-            "version": "0.49.2",
-            "resolved": "file:../vscode-azuretools/ui/vscode-azureextensionui-0.49.2.tgz",
-            "integrity": "sha512-kcKrqBpzxeU5KTIYqOU2/D0Y+mI5phw0GAYwRSRmSrjems3JDrFxHpDGp/aBTKZrU9fnML/tbgb0Thg63x86Cw==",
-            "license": "MIT",
+            "version": "0.49.3",
+            "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.49.3.tgz",
+            "integrity": "sha512-5A5zXsQ3oNqAYNBQcgmMV4djuFgcZV8t0ii8F9E/+rPbHmNmB5whR0IJPUE9WYMFBv44GKC5MKmJkUzilngD1g==",
             "dependencies": {
                 "@azure/arm-resources": "^4.0.0",
                 "@azure/arm-resources-profile-2020-09-01-hybrid": "^1.0.0",
@@ -20057,8 +20056,9 @@
             }
         },
         "vscode-azureextensionui": {
-            "version": "file:../vscode-azuretools/ui/vscode-azureextensionui-0.49.2.tgz",
-            "integrity": "sha512-kcKrqBpzxeU5KTIYqOU2/D0Y+mI5phw0GAYwRSRmSrjems3JDrFxHpDGp/aBTKZrU9fnML/tbgb0Thg63x86Cw==",
+            "version": "0.49.3",
+            "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.49.3.tgz",
+            "integrity": "sha512-5A5zXsQ3oNqAYNBQcgmMV4djuFgcZV8t0ii8F9E/+rPbHmNmB5whR0IJPUE9WYMFBv44GKC5MKmJkUzilngD1g==",
             "requires": {
                 "@azure/arm-resources": "^4.0.0",
                 "@azure/arm-resources-profile-2020-09-01-hybrid": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -855,7 +855,7 @@
         "mime": "^2.4.4",
         "open": "^8.0.4",
         "p-retry": "^4.2.0",
-        "vscode-azureextensionui": "^0.49.0",
+        "vscode-azureextensionui": "file:../vscode-azuretools/ui/vscode-azureextensionui-0.49.2.tgz",
         "vscode-nls": "^4.1.1",
         "winreg": "^1.2.3"
     },

--- a/package.json
+++ b/package.json
@@ -855,7 +855,7 @@
         "mime": "^2.4.4",
         "open": "^8.0.4",
         "p-retry": "^4.2.0",
-        "vscode-azureextensionui": "file:../vscode-azuretools/ui/vscode-azureextensionui-0.49.2.tgz",
+        "vscode-azureextensionui": "^0.49.3",
         "vscode-nls": "^4.1.1",
         "winreg": "^1.2.3"
     },

--- a/src/tree/createWizard/storageAccountCreateStep.ts
+++ b/src/tree/createWizard/storageAccountCreateStep.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { StorageManagementClient, StorageManagementModels } from '@azure/arm-storage';
-import { AzureWizardExecuteStep, INewStorageAccountDefaults, IStorageAccountWizardContext, LocationListStep, StorageAccountPerformance } from 'vscode-azureextensionui';
+import { AzureWizardExecuteStep, INewStorageAccountDefaults, IStorageAccountWizardContext, LocationListStep, StorageAccountKind, StorageAccountPerformance } from 'vscode-azureextensionui';
 import { NotificationProgress, storageProvider } from '../../constants';
 import { ext } from '../../extensionVariables';
 import { createStorageClient } from '../../utils/azureClients';
@@ -38,7 +38,7 @@ export class StorageAccountCreateStep<T extends IStorageAccountWizardContext> ex
             newName,
             {
                 sku: { name: newSkuName },
-                kind: this._defaults.kind,
+                kind: performance === StorageAccountPerformance.Premium ? StorageAccountKind.BlockBlobStorage : this._defaults.kind,
                 location,
                 extendedLocation,
                 enableHttpsTrafficOnly: true


### PR DESCRIPTION
We can only create Premium storage accounts in EdgeZones, and since we only support Premium Block Blob accounts, I think it makes sense to create this kind of account.

Depends on https://github.com/microsoft/vscode-azuretools/pull/1043

Fixes #1014 #1013 