### PR TITLE
Resolve storage accounts before trying to find Blob/File children

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azurestorage",
-    "version": "0.13.1-alpha.10",
+    "version": "0.13.1-alpha.11",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azurestorage",
-            "version": "0.13.1-alpha.10",
+            "version": "0.13.1-alpha.11",
             "hasInstallScript": true,
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-azurestorage",
     "displayName": "Azure Storage",
     "description": "Manage your Azure Storage accounts including Blob Containers, File Shares, Tables and Queues",
-    "version": "0.13.1-alpha.10",
+    "version": "0.13.1-alpha.11",
     "publisher": "ms-azuretools",
     "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
     "engines": {

--- a/src/AzureStorageFS.ts
+++ b/src/AzureStorageFS.ts
@@ -442,11 +442,15 @@ export class AzureStorageFS implements vscode.FileSystemProvider, vscode.TextDoc
         const rootName: string = path.basename(resourceId);
         const loadingMessage: string = this.isFileShareUri(uri) ? localize('loadingFileShare', 'Loading file share "{0}"...', rootName) : localize('loadingContainer', 'Loading blob container "{0}"...', rootName);
 
-        // the storage account needs to be resolved for the file system to read the files
-        const appResourceId = getAppResourceIdFromId(resourceId);
-        if (appResourceId) {
-            const appResource = await ext.rgApi.appResourceTree.findTreeItem(appResourceId, { ...context, loadAll: true }) as unknown as { resolve: () => Promise<void> }
-            await appResource.resolve();
+        try {
+            // the storage account needs to be resolved for the file system to read the files
+            const appResourceId = getAppResourceIdFromId(resourceId);
+            if (appResourceId) {
+                const appResource = await ext.rgApi.appResourceTree.findTreeItem(appResourceId, { ...context, loadAll: true }) as unknown as { resolve: () => Promise<void> }
+                await appResource.resolve();
+            }
+        } catch {
+            // swallow this error-- we don't want to abort this lookup
         }
 
         const treeItem = resourceId.includes('attachedStorageAccounts') ?

--- a/src/utils/azureUtils.ts
+++ b/src/utils/azureUtils.ts
@@ -13,3 +13,9 @@ function parseResourceId(id: string): RegExpMatchArray {
 export function getResourceGroupFromId(id: string): string {
     return parseResourceId(id)[2];
 }
+
+export function getAppResourceIdFromId(id: string): string | undefined {
+    const matches: RegExpMatchArray | null = id.match(/\/subscriptions\/.*\/resourceGroups\/.*\/providers\/Microsoft.Storage\/storageAccounts\/[^\/]*/);
+
+    return matches?.[0];
+}


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurestorage/issues/1042

When `findTreeItem` is called. It automatically calls getCachedChildren, but since the StorageTreeItem Proxy isn't resolved yet, it returns an empty array. 

It's being called by AzureFSProvider to get the blob container to display the blob and its contents in the file explorer.  I have a util function that only returns if there is a storage account AppResource attached to the blob/file share and resolves it,  If it is already resolved, it's a no-op so I don't feel too bad about always checking/resolving.