### PR TITLE
Directly access the root tree item like a criminal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azurestorage",
-    "version": "0.13.1-alpha.11",
+    "version": "0.13.1-alpha.12",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azurestorage",
-            "version": "0.13.1-alpha.11",
+            "version": "0.13.1-alpha.12",
             "hasInstallScript": true,
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-azurestorage",
     "displayName": "Azure Storage",
     "description": "Manage your Azure Storage accounts including Blob Containers, File Shares, Tables and Queues",
-    "version": "0.13.1-alpha.11",
+    "version": "0.13.1-alpha.12",
     "publisher": "ms-azuretools",
     "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
     "engines": {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurestorage/issues/1044

Also move the apiProvder activation in the `extension.activate`