### PR TITLE
Throw FileSystemError on readFile and stat

### DIFF
--- a/src/AzureStorageFS.ts
+++ b/src/AzureStorageFS.ts
@@ -107,9 +107,6 @@ export class AzureStorageFS implements vscode.FileSystemProvider, vscode.TextDoc
 
         return await callWithTelemetryAndErrorHandling('stat', async (context) => {
             context.telemetry.suppressIfSuccessful = true;
-            context.errorHandling.rethrow = true;
-            context.errorHandling.suppressDisplay = true;
-
             if (uri.path.endsWith('/')) {
                 // Ignore trailing forward slashes
                 // https://github.com/microsoft/vscode-azurestorage/issues/576


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurestorage/issues/1073
Fixes https://github.com/microsoft/vscode-azurestorage/issues/1093

When we changed to T2, I'm pretty sure that the errorTypes changed. Whenever a resource is not found, it throws a "404" rather than the other types that were previously there.

Also, stat would sometimes be called and would call `await fileClient.getProperties();` before we would actually delete the treeItem. 

I'm guessing that this started happening because when we moved to the RG view, rather checking the cache of Storage which is clearewd instantly, we call `await ext.rgApi.appResourceTree.findTreeItem(uriPath, { ...context, loadAll: true });`. I'm guessing RG wasn't clearing the child out fast enough before `stat` was called again.  This made it so treeItem was defined, we call `getProperties()`, ping Azure, only to throw a 404 because the file was actually deleted.