### PR TITLE
Remove leading slash from user input when creating a blob

### DIFF
--- a/src/commands/blob/blobContainerActionHandlers.ts
+++ b/src/commands/blob/blobContainerActionHandlers.ts
@@ -21,7 +21,7 @@ export function registerBlobContainerActionHandlers(): void {
     registerCommand("azureStorage.editBlob", async (context: IActionContext, treeItem: BlobTreeItem) => AzureStorageFS.showEditor(context, treeItem), 250);
     registerCommand("azureStorage.deleteBlobContainer", deleteBlobContainer);
     registerCommand("azureStorage.createBlockBlob", async (context: IActionContext, parent: BlobContainerTreeItem) => {
-        const blobPath: string = await getBlobPath(context, parent);
+        const blobPath: string = normalizeBlobPathInput(await getBlobPath(context, parent));
         const dirNames: string[] = blobPath.includes('/') ? path.dirname(blobPath).split('/') : [];
         let dirParentTreeItem: BlobDirectoryTreeItem | BlobContainerTreeItem = parent;
 
@@ -54,4 +54,11 @@ async function openBlobContainerInStorageExplorer(_context: IActionContext, tree
 
 export async function deleteBlobContainer(context: IActionContext, treeItem?: BlobContainerTreeItem): Promise<void> {
     await deleteNode(context, BlobContainerTreeItem.contextValue, treeItem);
+}
+
+/**
+ * Normalize and remove leading slash from path if present
+ */
+function normalizeBlobPathInput(blobPath: string): string {
+    return path.normalize(blobPath).replace(/^\/|\/$/g, '');
 }

--- a/src/tree/blob/BlobContainerTreeItem.ts
+++ b/src/tree/blob/BlobContainerTreeItem.ts
@@ -154,7 +154,7 @@ export class BlobContainerTreeItem extends AzExtParentTreeItem implements ICopyU
             context.showCreatingTreeItem(context.remoteFilePath);
             await this.uploadLocalFile(context, context.localFilePath, context.remoteFilePath);
             child = new BlobTreeItem(this, context.remoteFilePath, this.container);
-        } else if (context.childName && context.childType === BlobDirectoryTreeItem.contextValue) {
+        } else if ((context.childName !== undefined) && context.childType === BlobDirectoryTreeItem.contextValue) {
             child = new BlobDirectoryTreeItem(this, context.childName, this.container);
         } else {
             child = await createChildAsNewBlockBlob(this, context);

--- a/src/utils/blobUtils.ts
+++ b/src/utils/blobUtils.ts
@@ -61,7 +61,7 @@ export async function loadMoreBlobChildren(parent: BlobContainerTreeItem | BlobD
 
 // Currently only supports creating block blobs
 export async function createChildAsNewBlockBlob(parent: BlobContainerTreeItem | BlobDirectoryTreeItem, context: ICreateChildImplContext & IBlobContainerCreateChildContext): Promise<BlobTreeItem> {
-    const blobPath: string = context.childName || await getBlobPath(context, parent);
+    const blobPath: string = context.childName ?? await getBlobPath(context, parent);
 
     return await vscode.window.withProgress({ location: vscode.ProgressLocation.Window }, async (progress) => {
         context.showCreatingTreeItem(blobPath);


### PR DESCRIPTION
Fixes #970 

These changes do two things:

#### 1. Support creating blobs that have unnamed directories in their paths.

Yes this is actually allowed by Azure and is even displayed on the Portal.

The result of creating `/a/b/c/test.txt`:
<img width="282" alt="image" src="https://user-images.githubusercontent.com/12476526/184041393-18476211-8298-421e-bccd-497189e16cb8.png">

<img width="215" alt="image" src="https://user-images.githubusercontent.com/12476526/184043943-7c7f6595-24ff-4904-be36-734dd5b95c30.png">

#### 2. Strip any leading slash from user input so that it doesn't create an unnamed directories because that behavior is so weird.

I wanted to still add support for creating unnamed directories in case we allow this down the road for some reason.