### PR TITLE
Disable 'Open in Storage Explorer' default behavior when in a remote workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -337,7 +337,7 @@
                 {
                     "$comment": "========= azureStorageAccount =========",
                     "command": "azureStorage.openStorageAccount",
-                    "when": "view == azureResourceGroups && viewItem =~ /azureStorageAccount/ && !isWeb && !isLinux",
+                    "when": "view == azureResourceGroups && viewItem =~ /azureStorageAccount/ && !isWeb && !isLinux && !remoteName",
                     "group": "navigation@1"
                 },
                 {
@@ -711,6 +711,10 @@
                 {
                     "command": "azureStorage.uploadToAzureStorage",
                     "when": "never"
+                },
+                {
+                    "command": "azureStorage.openStorageAccount",
+                    "when": "!remoteName"
                 }
             ]
         },

--- a/src/commands/storageAccountActionHandlers.ts
+++ b/src/commands/storageAccountActionHandlers.ts
@@ -27,12 +27,6 @@ export function registerStorageAccountActionHandlers(): void {
 }
 
 async function openStorageAccountInStorageExplorer(context: IActionContext, treeItem?: ResolvedAppResourceTreeItem<ResolvedStorageAccount>): Promise<void> {
-    if (vscode.env.remoteName) {
-        const noRemoteSupport: string = localize('noRemoteSupport', 'This feature is not supported on remote workspaces.');
-        void context.ui.showWarningMessage(noRemoteSupport);
-        return;
-    }
-
     if (!treeItem) {
         treeItem = await ext.rgApi.pickAppResource<ResolvedAppResourceTreeItem<ResolvedStorageAccount> & AzExtTreeItem>(context, {
             filter: storageFilter,
@@ -41,6 +35,7 @@ async function openStorageAccountInStorageExplorer(context: IActionContext, tree
     }
 
     const accountId = treeItem.storageAccount.id;
+
     await storageExplorerLauncher.openResource(accountId, treeItem.subscription.subscriptionId);
 }
 

--- a/src/commands/storageAccountActionHandlers.ts
+++ b/src/commands/storageAccountActionHandlers.ts
@@ -29,7 +29,7 @@ export function registerStorageAccountActionHandlers(): void {
 async function openStorageAccountInStorageExplorer(context: IActionContext, treeItem?: ResolvedAppResourceTreeItem<ResolvedStorageAccount>): Promise<void> {
     if (vscode.env.remoteName) {
         const noRemoteSupport: string = localize('noRemoteSupport', 'This feature is not supported on remote workspaces.');
-        void vscode.window.showInformationMessage(noRemoteSupport);
+        void context.ui.showWarningMessage(noRemoteSupport);
         return;
     }
 

--- a/src/commands/storageAccountActionHandlers.ts
+++ b/src/commands/storageAccountActionHandlers.ts
@@ -27,6 +27,12 @@ export function registerStorageAccountActionHandlers(): void {
 }
 
 async function openStorageAccountInStorageExplorer(context: IActionContext, treeItem?: ResolvedAppResourceTreeItem<ResolvedStorageAccount>): Promise<void> {
+    if (vscode.env.remoteName) {
+        const noRemoteSupport: string = localize('noRemoteSupport', 'This feature is not supported on remote workspaces.');
+        void vscode.window.showInformationMessage(noRemoteSupport);
+        return;
+    }
+
     if (!treeItem) {
         treeItem = await ext.rgApi.pickAppResource<ResolvedAppResourceTreeItem<ResolvedStorageAccount> & AzExtTreeItem>(context, {
             filter: storageFilter,
@@ -35,7 +41,6 @@ async function openStorageAccountInStorageExplorer(context: IActionContext, tree
     }
 
     const accountId = treeItem.storageAccount.id;
-
     await storageExplorerLauncher.openResource(accountId, treeItem.subscription.subscriptionId);
 }
 


### PR DESCRIPTION
Fixes #1023 

Added a check when running `Open in Storage Explorer` that checks `remoteName`.  If populated, we warn that the feature is not supported and return..

![image](https://user-images.githubusercontent.com/40250218/184045191-6cb39fd0-16ae-464b-be03-76bd236f9ee9.png)
