### PR TITLE
Add delete many support for blob and fileshare (files/directories)

### DIFF
--- a/extension.bundle.ts
+++ b/extension.bundle.ts
@@ -14,9 +14,9 @@
 //
 // The tests should import '../extension.bundle.ts'. At design-time they live in tests/ and so will pick up this file (extension.bundle.ts).
 // At runtime the tests live in dist/tests and will therefore pick up the main webpack bundle at dist/extension.bundle.js.
-export * from '@microsoft/vscode-azext-utils';
 export * from '@microsoft/vscode-azext-azureutils';
-export * from './src/commands/blob/blobActionHandlers';
+export * from '@microsoft/vscode-azext-utils';
+export { ResolvedAppResourceTreeItem } from '@microsoft/vscode-azext-utils/hostapi';
 export * from './src/commands/blob/blobContainerActionHandlers';
 export * from './src/commands/blob/blobContainerGroupActionHandlers';
 export * from './src/commands/createStorageAccount';
@@ -30,12 +30,11 @@ export * from './src/commands/table/tableGroupActionHandlers';
 // Export activate/deactivate for main.js
 export { activateInternal, deactivateInternal } from './src/extension';
 export { ext } from './src/extensionVariables';
+export { ResolvedStorageAccount } from './src/StorageAccountResolver';
 export { AzureAccountTreeItem } from './src/tree/AzureAccountTreeItem';
 export { StorageAccountTreeItem } from './src/tree/StorageAccountTreeItem';
 export { AzExtFsExtra } from './src/utils/AzExtFsExtra';
 export { delay } from './src/utils/delay';
 export { getRandomHexString } from './src/utils/stringUtils';
-export { ResolvedAppResourceTreeItem } from '@microsoft/vscode-azext-utils/hostapi';
-export { ResolvedStorageAccount } from './src/StorageAccountResolver';
 
 // NOTE: The auto-fix action "source.organizeImports" does weird things with this file, but there doesn't seem to be a way to disable it on a per-file basis so we'll just let it happen

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
         "onCommand:azureStorage.createBlockBlob",
         "onCommand:azureStorage.uploadFiles",
         "onCommand:azureStorage.uploadFolder",
-        "onCommand:azureStorage.deleteBlob",
         "onCommand:azureStorage.download",
         "onCommand:azureStorage.createFileShare",
         "onCommand:azureStorage.deleteFileShare",
@@ -190,11 +189,6 @@
             {
                 "command": "azureStorage.uploadFolder",
                 "title": "Upload Folder...",
-                "category": "Azure Storage"
-            },
-            {
-                "command": "azureStorage.deleteBlob",
-                "title": "Delete...",
                 "category": "Azure Storage"
             },
             {
@@ -443,19 +437,13 @@
                     "group": "9_refresh"
                 },
                 {
-                    "$comment": "========= azureBlob =========",
-                    "command": "azureStorage.deleteBlob",
-                    "when": "view =~ /azure(Workspace|ResourceGroups)/i && viewItem == azureBlob || viewItem == azureBlobDirectory",
-                    "group": "7_modification"
-                },
-                {
                     "command": "azureStorage.download",
-                    "when": "view =~ /azure(Workspace|ResourceGroups)/i && viewItem == azureBlob",
+                    "when": "view =~ /azure(Workspace|ResourceGroups)/i && viewItem == azureBlobFile",
                     "group": "3_download"
                 },
                 {
                     "command": "azureStorage.copyUrl",
-                    "when": "view =~ /azure(Workspace|ResourceGroups)/i && viewItem == azureBlob",
+                    "when": "view =~ /azure(Workspace|ResourceGroups)/i && viewItem == azureBlobFile",
                     "group": "5_cutcopypaste"
                 },
                 {
@@ -539,7 +527,7 @@
                 },
                 {
                     "command": "azureStorage.deleteFile",
-                    "when": "view =~ /azure(Workspace|ResourceGroups)/i && viewItem == azureFile",
+                    "when": "view =~ /azure(Workspace|ResourceGroups)/i && viewItem == azureFile || viewItem == azureBlobFile",
                     "group": "7_modification"
                 },
                 {
@@ -565,7 +553,7 @@
                 },
                 {
                     "command": "azureStorage.deleteDirectory",
-                    "when": "view =~ /azure(Workspace|ResourceGroups)/i && viewItem == azureFileShareDirectory",
+                    "when": "view =~ /azure(Workspace|ResourceGroups)/i && viewItem == azureFileShareDirectory || viewItem == azureBlobDirectory",
                     "group": "7_modification"
                 },
                 {
@@ -644,10 +632,6 @@
                 },
                 {
                     "command": "azureStorage.createBlockBlob",
-                    "when": "never"
-                },
-                {
-                    "command": "azureStorage.deleteBlob",
                     "when": "never"
                 },
                 {

--- a/package.json
+++ b/package.json
@@ -198,11 +198,6 @@
                 "category": "Azure Storage"
             },
             {
-                "command": "azureStorage.deleteBlobDirectory",
-                "title": "Delete...",
-                "category": "Azure Storage"
-            },
-            {
                 "command": "azureStorage.download",
                 "title": "Download...",
                 "category": "Azure Storage"
@@ -450,7 +445,7 @@
                 {
                     "$comment": "========= azureBlob =========",
                     "command": "azureStorage.deleteBlob",
-                    "when": "view =~ /azure(Workspace|ResourceGroups)/i && viewItem == azureBlob",
+                    "when": "view =~ /azure(Workspace|ResourceGroups)/i && viewItem == azureBlob || viewItem == azureBlobDirectory",
                     "group": "7_modification"
                 },
                 {
@@ -464,12 +459,7 @@
                     "group": "5_cutcopypaste"
                 },
                 {
-                    "$comment": "========= azureBlobDirectory =========",
-                    "command": "azureStorage.deleteBlobDirectory",
-                    "when": "view =~ /azure(Workspace|ResourceGroups)/i && viewItem == azureBlobDirectory",
-                    "group": "7_modification"
-                },
-                {
+                    "$comment": "========= azureBlobDirectory ==========",
                     "command": "azureStorage.download",
                     "when": "view =~ /azure(Workspace|ResourceGroups)/i && viewItem == azureBlobDirectory",
                     "group": "3_download"
@@ -658,10 +648,6 @@
                 },
                 {
                     "command": "azureStorage.deleteBlob",
-                    "when": "never"
-                },
-                {
-                    "command": "azureStorage.deleteBlobDirectory",
                     "when": "never"
                 },
                 {

--- a/src/AzureStorageFS.ts
+++ b/src/AzureStorageFS.ts
@@ -301,9 +301,9 @@ export class AzureStorageFS implements vscode.FileSystemProvider, vscode.TextDoc
                         const parent = await this.lookupAsDirectory(parentUri, context, parsedUri.resourceId, parsedUri.parentDirPath);
 
                         if (writeToFileShare) {
-                            await parent.createChild(<IFileShareCreateChildContext>{ ...context, childType: 'azureFile', childName: parsedUri.baseName });
+                            await parent.createChild(<IFileShareCreateChildContext>{ ...context, childType: FileTreeItem.contextValue, childName: parsedUri.baseName });
                         } else {
-                            await parent.createChild(<IBlobContainerCreateChildContext>{ ...context, childType: 'azureBlob', childName: parsedUri.filePath });
+                            await parent.createChild(<IBlobContainerCreateChildContext>{ ...context, childType: BlobTreeItem.contextValue, childName: parsedUri.filePath });
                         }
                     }
                 });

--- a/src/commands/blob/blobActionHandlers.ts
+++ b/src/commands/blob/blobActionHandlers.ts
@@ -23,18 +23,18 @@ export async function deleteBlob(context: IActionContext, treeItem: BlobTreeItem
     }
 
     const dirPaths: string[] = [];
-    let shouldContinue;
+    let shouldSkip;
     for (const node of selection) {
-        shouldContinue = false;
+        shouldSkip = false;
 
-        // Check to see if it's a child we've already deleted
+        // Check to see if it's a resource we've already deleted
         for (const dirPath of dirPaths) {
             if (isSubpath(dirPath, node.fullId)) {
-                shouldContinue = true;
+                shouldSkip = true;
                 break;
             }
         }
-        if (shouldContinue) continue;
+        if (shouldSkip) continue;
         if (isTreeItemDirectory(node)) {
             dirPaths.push(node.fullId);
         }

--- a/src/commands/blob/blobActionHandlers.ts
+++ b/src/commands/blob/blobActionHandlers.ts
@@ -3,9 +3,6 @@
  *  Licensed under the MIT License. See License.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { registerCommand } from "@microsoft/vscode-azext-utils";
-import { deleteFilesAndDirectories } from "../deleteFilesAndDirectories";
-
 export function registerBlobActionHandlers(): void {
-    registerCommand("azureStorage.deleteBlob", deleteFilesAndDirectories);
+    // Placeholder
 }

--- a/src/commands/blob/blobActionHandlers.ts
+++ b/src/commands/blob/blobActionHandlers.ts
@@ -14,9 +14,7 @@ export function registerBlobActionHandlers(): void {
     registerCommand("azureStorage.deleteBlob", deleteBlob);
 }
 
-export async function deleteBlob(context: IActionContext, treeItem: BlobTreeItem | BlobDirectoryTreeItem): Promise<void> {
-    const { selection } = ext.rgApi.appResourceTreeView;
-
+export async function deleteBlob(context: IActionContext, treeItem: BlobTreeItem | BlobDirectoryTreeItem, selection: (BlobTreeItem | BlobDirectoryTreeItem)[] = []): Promise<void> {
     // Covers both single selection and an edge case where the node you delete from isn't part of the selection
     if (!selection.some(s => s === treeItem)) {
         await ext.rgApi.appResourceTreeView.reveal(treeItem);

--- a/src/commands/blob/blobActionHandlers.ts
+++ b/src/commands/blob/blobActionHandlers.ts
@@ -22,11 +22,12 @@ export async function deleteBlob(context: IActionContext, treeItem: BlobTreeItem
         return;
     }
 
-    // When deleting a directory, go through the remaining selections and check to see if it's a child we've already deleted
     const dirPaths: string[] = [];
     let shouldContinue;
     for (const node of selection) {
         shouldContinue = false;
+
+        // Check to see if it's a child we've already deleted
         for (const dirPath of dirPaths) {
             if (isSubpath(dirPath, node.fullId)) {
                 shouldContinue = true;

--- a/src/commands/blob/blobActionHandlers.ts
+++ b/src/commands/blob/blobActionHandlers.ts
@@ -22,16 +22,20 @@ export async function deleteBlob(context: IActionContext, treeItem: BlobTreeItem
         return;
     }
 
-    for (const [n, node] of selection.entries()) {
-        // When deleting a directory, go through the remaining selections and check to see if it's a child we've already deleted
-        if (isTreeItemDirectory(node)) {
-            for (let i = n + 1; i < selection.length; i++) {
-                const unverifiedNode = selection[i];
-                if (isSubpath(node.fullId, unverifiedNode.fullId)) {
-                    selection.splice(i, 1);
-                    i--;
-                }
+    // When deleting a directory, go through the remaining selections and check to see if it's a child we've already deleted
+    const dirPaths: string[] = [];
+    let shouldContinue;
+    for (const node of selection) {
+        shouldContinue = false;
+        for (const dirPath of dirPaths) {
+            if (isSubpath(dirPath, node.fullId)) {
+                shouldContinue = true;
+                break;
             }
+        }
+        if (shouldContinue) continue;
+        if (isTreeItemDirectory(node)) {
+            dirPaths.push(node.fullId);
         }
         await node.deleteTreeItem(context);
     }

--- a/src/commands/blob/blobActionHandlers.ts
+++ b/src/commands/blob/blobActionHandlers.ts
@@ -4,14 +4,25 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IActionContext, registerCommand } from "@microsoft/vscode-azext-utils";
+import { ext } from "../../extensionVariables";
 import { BlobDirectoryTreeItem } from "../../tree/blob/BlobDirectoryTreeItem";
 import { BlobTreeItem } from "../../tree/blob/BlobTreeItem";
 
 export function registerBlobActionHandlers(): void {
     registerCommand("azureStorage.deleteBlob", deleteBlob);
-    registerCommand("azureStorage.deleteBlobDirectory", async (context: IActionContext, treeItem: BlobDirectoryTreeItem) => await treeItem.deleteTreeItem(context));
 }
 
-export async function deleteBlob(context: IActionContext, treeItem: BlobTreeItem): Promise<void> {
-    await treeItem.deleteTreeItem(context);
+export async function deleteBlob(context: IActionContext, treeItem: BlobTreeItem | BlobDirectoryTreeItem): Promise<void> {
+    const { selection } = ext.rgApi.appResourceTreeView;
+
+    // Covers both single selection and an edge case where the node you delete from isn't part of the selection
+    if (!selection.some(s => s === treeItem)) {
+        await ext.rgApi.appResourceTreeView.reveal(treeItem);
+        await treeItem.deleteTreeItem(context);
+        return;
+    }
+
+    for (const node of selection) {
+        await node.deleteTreeItem(context);
+    }
 }

--- a/src/commands/blob/blobActionHandlers.ts
+++ b/src/commands/blob/blobActionHandlers.ts
@@ -3,41 +3,9 @@
  *  Licensed under the MIT License. See License.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IActionContext, registerCommand } from "@microsoft/vscode-azext-utils";
-import { ext } from "../../extensionVariables";
-import { BlobDirectoryTreeItem } from "../../tree/blob/BlobDirectoryTreeItem";
-import { BlobTreeItem } from "../../tree/blob/BlobTreeItem";
-import { isTreeItemDirectory } from "../../utils/directoryUtils";
-import { isSubpath } from "../../utils/fs";
+import { registerCommand } from "@microsoft/vscode-azext-utils";
+import { deleteFilesAndDirectories } from "../deleteFilesAndDirectories";
 
 export function registerBlobActionHandlers(): void {
-    registerCommand("azureStorage.deleteBlob", deleteBlob);
-}
-
-export async function deleteBlob(context: IActionContext, treeItem: BlobTreeItem | BlobDirectoryTreeItem, selection: (BlobTreeItem | BlobDirectoryTreeItem)[] = []): Promise<void> {
-    // Covers both single selection and an edge case where the node you delete from isn't part of the selection
-    if (!selection.some(s => s === treeItem)) {
-        await ext.rgApi.appResourceTreeView.reveal(treeItem);
-        await treeItem.deleteTreeItem(context);
-        return;
-    }
-
-    const dirPaths: string[] = [];
-    let shouldSkip;
-    for (const node of selection) {
-        shouldSkip = false;
-
-        // Check to see if it's a resource we've already deleted
-        for (const dirPath of dirPaths) {
-            if (isSubpath(dirPath, node.fullId)) {
-                shouldSkip = true;
-                break;
-            }
-        }
-        if (shouldSkip) continue;
-        if (isTreeItemDirectory(node)) {
-            dirPaths.push(node.fullId);
-        }
-        await node.deleteTreeItem(context);
-    }
+    registerCommand("azureStorage.deleteBlob", deleteFilesAndDirectories);
 }

--- a/src/commands/blob/blobActionHandlers.ts
+++ b/src/commands/blob/blobActionHandlers.ts
@@ -1,8 +1,0 @@
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.md in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
-
-export function registerBlobActionHandlers(): void {
-    // Placeholder
-}

--- a/src/commands/deleteFilesAndDirectories.ts
+++ b/src/commands/deleteFilesAndDirectories.ts
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { AzExtTreeItem, IActionContext } from "@microsoft/vscode-azext-utils";
+import { ext } from "../extensionVariables";
+import { isTreeItemDirectory } from "../utils/directoryUtils";
+import { isSubpath } from "../utils/fs";
+
+export async function deleteFilesAndDirectories(context: IActionContext, treeItem: AzExtTreeItem, selection: AzExtTreeItem[] = []): Promise<void> {
+    // Covers both single selection and an edge case where the node you delete from isn't part of the selection
+    if (!selection.some(s => s === treeItem)) {
+        await ext.rgApi.appResourceTreeView.reveal(treeItem);
+        await treeItem.deleteTreeItem(context);
+        return;
+    }
+
+    const dirPaths: string[] = [];
+    let shouldSkip;
+    for (const node of selection) {
+        shouldSkip = false;
+
+        // Check to see if it's a resource we've already deleted
+        for (const dirPath of dirPaths) {
+            if (isSubpath(dirPath, node.fullId)) {
+                shouldSkip = true;
+                break;
+            }
+        }
+        if (shouldSkip) continue;
+        if (isTreeItemDirectory(node)) {
+            dirPaths.push(node.fullId);
+        }
+        await node.deleteTreeItem(context);
+    }
+}

--- a/src/commands/fileShare/directoryActionHandlers.ts
+++ b/src/commands/fileShare/directoryActionHandlers.ts
@@ -6,9 +6,10 @@
 import { AzExtParentTreeItem, IActionContext, registerCommand } from '@microsoft/vscode-azext-utils';
 import { DirectoryTreeItem } from '../../tree/fileShare/DirectoryTreeItem';
 import { IFileShareCreateChildContext } from '../../tree/fileShare/FileShareTreeItem';
+import { deleteFilesAndDirectories } from '../deleteFilesAndDirectories';
 
 export function registerDirectoryActionHandlers(): void {
-    registerCommand("azureStorage.deleteDirectory", async (context: IActionContext, treeItem: AzExtParentTreeItem) => await treeItem.deleteTreeItem(context));
+    registerCommand("azureStorage.deleteDirectory", deleteFilesAndDirectories);
     registerCommand("azureStorage.createSubdirectory", async (context: IActionContext, treeItem: AzExtParentTreeItem) => await treeItem.createChild(<IFileShareCreateChildContext>{ ...context, childType: DirectoryTreeItem.contextValue }));
 
     // Note: azureStorage.createTextFile is registered in fileShareActionHandlers

--- a/src/commands/fileShare/fileActionHandlers.ts
+++ b/src/commands/fileShare/fileActionHandlers.ts
@@ -3,9 +3,9 @@
  *  Licensed under the MIT License. See License.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IActionContext, registerCommand } from '@microsoft/vscode-azext-utils';
-import { FileTreeItem } from '../../tree/fileShare/FileTreeItem';
+import { registerCommand } from '@microsoft/vscode-azext-utils';
+import { deleteFilesAndDirectories } from '../deleteFilesAndDirectories';
 
 export function registerFileActionHandlers(): void {
-    registerCommand("azureStorage.deleteFile", async (context: IActionContext, treeItem: FileTreeItem) => await treeItem.deleteTreeItem(context));
+    registerCommand("azureStorage.deleteFile", deleteFilesAndDirectories);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,7 +13,6 @@ import * as vscode from 'vscode';
 import { commands } from 'vscode';
 import { AzureStorageFS } from './AzureStorageFS';
 import { revealTreeItem } from './commands/api/revealTreeItem';
-import { registerBlobActionHandlers } from './commands/blob/blobActionHandlers';
 import { registerBlobContainerActionHandlers } from './commands/blob/blobContainerActionHandlers';
 import { registerBlobContainerGroupActionHandlers } from './commands/blob/blobContainerGroupActionHandlers';
 import { createStorageAccount, createStorageAccountAdvanced } from './commands/createStorageAccount';
@@ -59,7 +58,6 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
         activateContext.telemetry.properties.isActivationEvent = 'true';
         activateContext.telemetry.measurements.mainFileLoad = (perfStats.loadEndTime - perfStats.loadStartTime) / 1000;
 
-        registerBlobActionHandlers();
         registerBlobContainerActionHandlers();
         registerBlobContainerGroupActionHandlers();
         registerFileActionHandlers();

--- a/src/tree/blob/BlobTreeItem.ts
+++ b/src/tree/blob/BlobTreeItem.ts
@@ -22,7 +22,7 @@ import { BlobContainerTreeItem } from "./BlobContainerTreeItem";
 import { BlobDirectoryTreeItem } from "./BlobDirectoryTreeItem";
 
 export class BlobTreeItem extends AzExtTreeItem implements ICopyUrl, IStorageTreeItem {
-    public static contextValue: string = 'azureBlob';
+    public static contextValue: string = 'azureBlobFile';
     public contextValue: string = BlobTreeItem.contextValue;
     public parent: BlobContainerTreeItem | BlobDirectoryTreeItem;
 

--- a/src/utils/directoryUtils.ts
+++ b/src/utils/directoryUtils.ts
@@ -86,6 +86,5 @@ export async function doesDirectoryExist(parent: FileShareTreeItem | DirectoryTr
 }
 
 export function isTreeItemDirectory(node: AzExtTreeItem): boolean {
-    const dirRegEx = /directory/i;
-    return (node.contextValue.match(dirRegEx)) ? true : false;
+    return /directory/i.test(node.contextValue);
 }

--- a/src/utils/directoryUtils.ts
+++ b/src/utils/directoryUtils.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as azureStorageShare from "@azure/storage-file-share";
-import { ICreateChildImplContext } from "@microsoft/vscode-azext-utils";
+import { AzExtTreeItem, ICreateChildImplContext } from "@microsoft/vscode-azext-utils";
 import * as path from "path";
 import { ProgressLocation, window } from "vscode";
 import { maxPageSize } from "../constants";
@@ -83,4 +83,9 @@ export async function doesDirectoryExist(parent: FileShareTreeItem | DirectoryTr
     } catch {
         return false;
     }
+}
+
+export function isTreeItemDirectory(node: AzExtTreeItem): boolean {
+    const dirRegEx = /directory/i;
+    return (node.contextValue.match(dirRegEx)) ? true : false;
 }


### PR DESCRIPTION
Closes #951 
Closes #1114 

Added support and consolidated the number of `deleteBlob` commands.  Will look into doing something similar for FileShare in the near future... (likely could consolidate most of the delete code into one command but would need to investigate further)

There's two edge cases that I'm covering in this iteration:

<b>Case 1</b>:  If you select multiple items but then right click and delete a different (non-selected) node... 

I decided to model the behavior off of how deleting worked in the normal Windows FS GUI (so basically, only delete the right clicked node when it's not part of the normal selection)

![image](https://user-images.githubusercontent.com/40250218/184265726-083616c7-a1eb-4096-8acc-10ec564e7f2e.png)

<b>Case 2</b>:  If your selection includes files that are nested in directories of other selections...

![image](https://user-images.githubusercontent.com/40250218/184265529-838fe0a4-0084-49d5-bb58-af333231a8a1.png)

To avoid `not found` errors, I check to see if each node is a directory.  If it is, I go through the remaining nodes and check to see if they are subPaths.  If they are, I remove them from the remaining list.  The implementation uses a nested for loop which I wasn't thrilled about, but I didn't have an obvious alternative that I liked and felt that the average user's selection size probably wasn't anything that would scale out of control.  If you have a better suggestion though, please let me know.  Thanks!
