### PR TITLE
Declare limited support for virtual workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,12 @@
     ],
     "main": "main",
     "icon": "resources/storageAccount.png",
+    "capabilities": {
+        "virtualWorkspaces": {
+            "supported": "limited",
+            "description": "In virtual workspaces, uploading files or folders to Azure Storage is not supported."
+        }
+    },
     "contributes": {
         "x-azResources": {
             "activation": {


### PR DESCRIPTION
Browsing accounts, creating accounts, etc. still works. Haven't tested everything but I guess declaring limited support is better than being disabled by default.