### PR TITLE
Add command to get SAS url for Blobs/FileShares

### DIFF
--- a/package.json
+++ b/package.json
@@ -347,7 +347,7 @@
                 },
                 {
                     "command": "azureStorage.copyConnectionString",
-                    "when": "view =~ /azure(ResourceGroups|Workspace)/i && viewItem =~ /azureStorageAccount/",
+                    "when": "view == azureResourceGroups && viewItem =~ /azureStorageAccount/",
                     "group": "5_cutcopypaste@1"
                 },
                 {
@@ -459,7 +459,7 @@
                 },
                 {
                     "command": "azureStorage.generateSASUrl",
-                    "when": "view =~ /azure(ResourceGroups|Workspace)/i && viewItem == azureBlobFile",
+                    "when": "view == azureResourceGroups && viewItem == azureBlobFile",
                     "group": "5_cutcopypaste@2"
                 },
                 {
@@ -475,7 +475,7 @@
                 },
                 {
                     "command": "azureStorage.generateSASUrl",
-                    "when": "view =~ /azure(ResourceGroups|Workspace)/i && viewItem == azureBlobDirectory",
+                    "when": "view == azureResourceGroups && viewItem == azureBlobDirectory",
                     "group": "5_cutcopypaste@2"
                 },
                 {
@@ -522,7 +522,7 @@
                 },
                 {
                     "command": "azureStorage.generateSASUrl",
-                    "when": "view =~ /azure(ResourceGroups|Workspace)/i && viewItem == azureFileShare",
+                    "when": "view == azureResourceGroups && viewItem == azureFileShare",
                     "group": "5_cutcopypaste@2"
                 },
                 {
@@ -553,7 +553,7 @@
                 },
                 {
                     "command": "azureStorage.generateSASUrl",
-                    "when": "view =~ /azure(ResourceGroups|Workspace)/i && viewItem == azureFile",
+                    "when": "view == azureResourceGroups && viewItem == azureFile",
                     "group": "5_cutcopypaste@2"
                 },
                 {
@@ -584,7 +584,7 @@
                 },
                 {
                     "command": "azureStorage.generateSASUrl",
-                    "when": "view =~ /azure(ResourceGroups|Workspace)/i && viewItem == azureFileShareDirectory",
+                    "when": "view == azureResourceGroups && viewItem == azureFileShareDirectory",
                     "group": "5_cutcopypaste@2"
                 },
                 {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
         "onCommand:azureStorage.startBlobEmulator",
         "onCommand:azureStorage.startQueueEmulator",
         "onCommand:azureStorage.reportIssue",
+        "onCommand:azureStorage.generateSASUrl",
         "onView:azureWorkspace"
     ],
     "main": "main",
@@ -297,6 +298,11 @@
                 "command": "azureStorage.reportIssue",
                 "title": "Report Issue...",
                 "category": "Azure Storage"
+            },
+            {
+                "command": "azureStorage.generateSASUrl",
+                "title": "Generate & Copy SAS Token and URL",
+                "category": "Azure Storage"
             }
         ],
         "menus": {
@@ -407,6 +413,11 @@
                     "group": "5_cutcopypaste"
                 },
                 {
+                    "command": "azureStorage.generateSASUrl",
+                    "when": "view =~ /azure(ResourceGroups|Workspace)/i && viewItem == azureBlobContainer",
+                    "group": "5_cutcopypaste@2"
+                },
+                {
                     "command": "azureStorage.browseStaticWebsite",
                     "when": "view =~ /azure(Workspace|ResourceGroups)/i && viewItem == azureBlobContainer",
                     "group": "6_staticwebsites@1"
@@ -444,7 +455,12 @@
                 {
                     "command": "azureStorage.copyUrl",
                     "when": "view =~ /azure(Workspace|ResourceGroups)/i && viewItem == azureBlobFile",
-                    "group": "5_cutcopypaste"
+                    "group": "5_cutcopypaste@1"
+                },
+                {
+                    "command": "azureStorage.generateSASUrl",
+                    "when": "view =~ /azure(ResourceGroups|Workspace)/i && viewItem == azureBlobFile",
+                    "group": "5_cutcopypaste@2"
                 },
                 {
                     "$comment": "========= azureBlobDirectory ==========",
@@ -455,7 +471,12 @@
                 {
                     "command": "azureStorage.copyUrl",
                     "when": "view =~ /azure(Workspace|ResourceGroups)/i && viewItem == azureBlobDirectory",
-                    "group": "5_cutcopypaste"
+                    "group": "5_cutcopypaste@1"
+                },
+                {
+                    "command": "azureStorage.generateSASUrl",
+                    "when": "view =~ /azure(ResourceGroups|Workspace)/i && viewItem == azureBlobDirectory",
+                    "group": "5_cutcopypaste@2"
                 },
                 {
                     "$comment": "========= azureFileShareGroup =========",
@@ -497,7 +518,12 @@
                 {
                     "command": "azureStorage.copyUrl",
                     "when": "view =~ /azure(Workspace|ResourceGroups)/i && viewItem == azureFileShare",
-                    "group": "5_cutcopypaste"
+                    "group": "5_cutcopypaste@1"
+                },
+                {
+                    "command": "azureStorage.generateSASUrl",
+                    "when": "view =~ /azure(ResourceGroups|Workspace)/i && viewItem == azureFileShare",
+                    "group": "5_cutcopypaste@2"
                 },
                 {
                     "command": "azureStorage.deleteFileShare",
@@ -523,7 +549,12 @@
                 {
                     "command": "azureStorage.copyUrl",
                     "when": "view =~ /azure(Workspace|ResourceGroups)/i && viewItem == azureFile",
-                    "group": "5_cutcopypaste"
+                    "group": "5_cutcopypaste@1"
+                },
+                {
+                    "command": "azureStorage.generateSASUrl",
+                    "when": "view =~ /azure(ResourceGroups|Workspace)/i && viewItem == azureFile",
+                    "group": "5_cutcopypaste@2"
                 },
                 {
                     "command": "azureStorage.deleteFile",
@@ -549,7 +580,12 @@
                 {
                     "command": "azureStorage.copyUrl",
                     "when": "view =~ /azure(Workspace|ResourceGroups)/i && viewItem == azureFileShareDirectory",
-                    "group": "5_cutcopypaste"
+                    "group": "5_cutcopypaste@1"
+                },
+                {
+                    "command": "azureStorage.generateSASUrl",
+                    "when": "view =~ /azure(ResourceGroups|Workspace)/i && viewItem == azureFileShareDirectory",
+                    "group": "5_cutcopypaste@2"
                 },
                 {
                     "command": "azureStorage.deleteDirectory",

--- a/package.json
+++ b/package.json
@@ -414,7 +414,7 @@
                 },
                 {
                     "command": "azureStorage.generateSASUrl",
-                    "when": "view =~ /azure(ResourceGroups|Workspace)/i && viewItem == azureBlobContainer",
+                    "when": "view == azureResourceGroups && viewItem == azureBlobContainer",
                     "group": "5_cutcopypaste@2"
                 },
                 {

--- a/src/commands/azCopy/azCopyLocations.ts
+++ b/src/commands/azCopy/azCopyLocations.ts
@@ -4,19 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ILocalLocation, IRemoteSasLocation } from "@azure-tools/azcopy-node";
-import { AccountSASPermissions, AccountSASSignatureValues, ContainerClient } from "@azure/storage-blob";
-import { ShareClient } from "@azure/storage-file-share";
 import { posix, sep } from "path";
-import { BlobContainerTreeItem } from "../../tree/blob/BlobContainerTreeItem";
-import { BlobDirectoryTreeItem } from "../../tree/blob/BlobDirectoryTreeItem";
-import { BlobTreeItem } from "../../tree/blob/BlobTreeItem";
-import { DirectoryTreeItem } from "../../tree/fileShare/DirectoryTreeItem";
-import { FileShareTreeItem } from "../../tree/fileShare/FileShareTreeItem";
-import { FileTreeItem } from "../../tree/fileShare/FileTreeItem";
-import { createBlobContainerClient } from "../../utils/blobUtils";
-import { createShareClient } from "../../utils/fileUtils";
-
-const threeDaysInMS: number = 1000 * 60 * 60 * 24 * 3;
+import { IStorageTreeItem } from "../../tree/IStorageTreeItem";
+import { getResourceUri } from "../downloadFiles/getResourceUri";
+import { getSasToken } from "../downloadFiles/getSasToken";
 
 export function createAzCopyLocalLocation(path: string, isFolder?: boolean): ILocalLocation {
     if (isFolder && !path.endsWith(sep)) {
@@ -25,27 +16,13 @@ export function createAzCopyLocalLocation(path: string, isFolder?: boolean): ILo
     return { type: 'Local', path, useWildCard: !!isFolder };
 }
 
-export function createAzCopyRemoteLocation(treeItem: BlobTreeItem | BlobDirectoryTreeItem | BlobContainerTreeItem | FileTreeItem | DirectoryTreeItem | FileShareTreeItem, path: string, isFolder?: boolean): IRemoteSasLocation {
+export function createAzCopyRemoteLocation(treeItem: IStorageTreeItem, path: string, isFolder?: boolean): IRemoteSasLocation {
     if (isFolder && !path.endsWith(posix.sep)) {
         path += posix.sep;
     }
 
-    let resourceUri: string;
-    if (treeItem instanceof BlobTreeItem || treeItem instanceof BlobDirectoryTreeItem || treeItem instanceof BlobContainerTreeItem) {
-        const containerClient: ContainerClient = createBlobContainerClient(treeItem.root, treeItem.container.name);
-        resourceUri = containerClient.url;
-    } else {
-        const shareClient: ShareClient = createShareClient(treeItem.root, treeItem.shareName);
-        resourceUri = shareClient.url;
-    }
-
-    const accountSASSignatureValues: AccountSASSignatureValues = {
-        expiresOn: new Date(Date.now() + threeDaysInMS),
-        permissions: AccountSASPermissions.parse('rwl'), // read, write, list
-        services: 'bf', // blob, file
-        resourceTypes: 'co' // container, object
-    };
-    const sasToken: string = treeItem.root.generateSasToken(accountSASSignatureValues);
+    const resourceUri: string = getResourceUri(treeItem);
+    const sasToken: string = getSasToken(treeItem.root);
     // Ensure path begins with '/' to transfer properly
     path = path[0] === posix.sep ? path : `${posix.sep}${path}`;
     return { type: 'RemoteSas', sasToken, resourceUri, path, useWildCard: !!isFolder };

--- a/src/commands/downloadFile.ts
+++ b/src/commands/downloadFile.ts
@@ -5,7 +5,7 @@
 
 import { FromToOption, ILocalLocation, IRemoteSasLocation } from "@azure-tools/azcopy-node";
 import { AzExtTreeItem, IActionContext } from "@microsoft/vscode-azext-utils";
-import { join, posix } from "path";
+import { join } from "path";
 import { ProgressLocation, window } from "vscode";
 import { configurationSettingsKeys } from "../constants";
 import { ext } from "../extensionVariables";
@@ -68,7 +68,7 @@ async function getAzCopyDownloads(context: IActionContext, destinationFolder: st
             await treeItem.checkCanDownload(context);
             allFileDownloads.push({
                 remoteFileName: treeItem.blobName,
-                remoteFilePath: treeItem.blobPath,
+                remoteFilePath: treeItem.remoteFilePath,
                 localFilePath: join(destinationFolder, treeItem.blobName),
                 fromTo: 'BlobLocal',
                 isDirectory: false,
@@ -77,7 +77,7 @@ async function getAzCopyDownloads(context: IActionContext, destinationFolder: st
         } else if (treeItem instanceof BlobDirectoryTreeItem) {
             allFolderDownloads.push({
                 remoteFileName: treeItem.dirName,
-                remoteFilePath: treeItem.dirPath,
+                remoteFilePath: treeItem.remoteFilePath,
                 localFilePath: join(destinationFolder, treeItem.dirName),
                 fromTo: 'BlobLocal',
                 isDirectory: true,
@@ -86,7 +86,7 @@ async function getAzCopyDownloads(context: IActionContext, destinationFolder: st
         } else if (treeItem instanceof FileTreeItem) {
             allFileDownloads.push({
                 remoteFileName: treeItem.fileName,
-                remoteFilePath: posix.join(treeItem.directoryPath, treeItem.fileName),
+                remoteFilePath: treeItem.remoteFilePath,
                 localFilePath: join(destinationFolder, treeItem.fileName),
                 fromTo: 'FileLocal',
                 isDirectory: false,

--- a/src/commands/downloadFile.ts
+++ b/src/commands/downloadFile.ts
@@ -95,7 +95,7 @@ async function getAzCopyDownloads(context: IActionContext, destinationFolder: st
         } else if (treeItem instanceof DirectoryTreeItem) {
             allFolderDownloads.push({
                 remoteFileName: treeItem.directoryName,
-                remoteFilePath: posix.join(treeItem.parentPath, treeItem.directoryName),
+                remoteFilePath: treeItem.remoteFilePath,
                 localFilePath: join(destinationFolder, treeItem.directoryName),
                 fromTo: 'FileLocal',
                 isDirectory: true,

--- a/src/commands/downloadFiles/generateSasUrl.ts
+++ b/src/commands/downloadFiles/generateSasUrl.ts
@@ -5,8 +5,8 @@
 
 import { IActionContext } from '@microsoft/vscode-azext-utils';
 import { posix } from 'path';
-import { env } from 'vscode';
 import { IDownloadableTreeItem } from '../../tree/IDownloadableTreeItem';
+import { copyAndShowToast } from '../../utils/copyAndShowToast';
 import { getResourceUri } from './getResourceUri';
 import { getSasToken } from './getSasToken';
 
@@ -15,6 +15,6 @@ export async function generateSASUrl(_context: IActionContext, treeItem: IDownlo
     const sasToken = getSasToken(treeItem.root);
 
     const sasUrl: string = `${resourceUri}${posix.sep}${treeItem.remoteFilePath}?${sasToken}`;
-    await env.clipboard.writeText(sasUrl);
+    await copyAndShowToast(sasUrl, 'SAS Token and URL');
     return sasUrl;
 }

--- a/src/commands/downloadFiles/generateSasUrl.ts
+++ b/src/commands/downloadFiles/generateSasUrl.ts
@@ -1,0 +1,20 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IActionContext } from '@microsoft/vscode-azext-utils';
+import { posix } from 'path';
+import { env } from 'vscode';
+import { IDownloadableTreeItem } from '../../tree/IDownloadableTreeItem';
+import { getResourceUri } from './getResourceUri';
+import { getSasToken } from './getSasToken';
+
+export async function generateSASUrl(_context: IActionContext, treeItem: IDownloadableTreeItem): Promise<string> {
+    const resourceUri = getResourceUri(treeItem);
+    const sasToken = getSasToken(treeItem.root);
+
+    const sasUrl: string = `${resourceUri}${posix.sep}${treeItem.remoteFilePath}?${sasToken}`;
+    await env.clipboard.writeText(sasUrl);
+    return sasUrl;
+}

--- a/src/commands/downloadFiles/getResourceUri.ts
+++ b/src/commands/downloadFiles/getResourceUri.ts
@@ -1,0 +1,25 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ContainerClient } from "@azure/storage-blob";
+import { ShareClient } from "@azure/storage-file-share";
+import { nonNullProp } from "@microsoft/vscode-azext-utils";
+import { BlobContainerTreeItem } from "../../tree/blob/BlobContainerTreeItem";
+import { BlobDirectoryTreeItem } from "../../tree/blob/BlobDirectoryTreeItem";
+import { BlobTreeItem } from "../../tree/blob/BlobTreeItem";
+import { IStorageTreeItem } from "../../tree/IStorageTreeItem";
+import { createBlobContainerClient } from "../../utils/blobUtils";
+import { createShareClient } from "../../utils/fileUtils";
+
+export function getResourceUri(treeItem: IStorageTreeItem & Partial<{ shareName?: string }>): string {
+    if (treeItem instanceof BlobTreeItem || treeItem instanceof BlobDirectoryTreeItem || treeItem instanceof BlobContainerTreeItem) {
+        const containerClient: ContainerClient = createBlobContainerClient(treeItem.root, treeItem.container.name);
+        return containerClient.url;
+    } else {
+        // if not a Blob, then one of these types: FileTreeItem | DirectoryTreeItem | FileShareTreeItem
+        const shareClient: ShareClient = createShareClient(treeItem.root, nonNullProp(treeItem, 'shareName'));
+        return shareClient.url;
+    }
+}

--- a/src/commands/downloadFiles/getSasToken.ts
+++ b/src/commands/downloadFiles/getSasToken.ts
@@ -1,0 +1,19 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { AccountSASPermissions, AccountSASSignatureValues } from '@azure/storage-blob';
+import { IStorageRoot } from '../../tree/IStorageRoot';
+
+const threeDaysInMS: number = 1000 * 60 * 60 * 24 * 3;
+
+export function getSasToken(root: IStorageRoot): string {
+    const accountSASSignatureValues: AccountSASSignatureValues = {
+        expiresOn: new Date(Date.now() + threeDaysInMS),
+        permissions: AccountSASPermissions.parse('rwl'), // read, write, list
+        services: 'bf', // blob, file
+        resourceTypes: 'co' // container, object
+    };
+    return root.generateSasToken(accountSASSignatureValues);
+}

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -17,6 +17,7 @@ import { registerBlobContainerGroupActionHandlers } from "./blob/blobContainerGr
 import { createStorageAccount, createStorageAccountAdvanced } from "./createStorageAccount";
 import { detachStorageAccount } from "./detachStorageAccount";
 import { download } from "./downloadFile";
+import { generateSASUrl } from "./downloadFiles/generateSasUrl";
 import { registerDirectoryActionHandlers } from "./fileShare/directoryActionHandlers";
 import { registerFileActionHandlers } from "./fileShare/fileActionHandlers";
 import { registerFileShareActionHandlers } from "./fileShare/fileShareActionHandlers";
@@ -107,6 +108,7 @@ export function registerCommands(): void {
     registerCommand("azureStorage.uploadFolder", uploadFolder);
     registerCommand("azureStorage.uploadToAzureStorage", uploadToAzureStorage);
     registerCommand('azureStorage.download', download);
+    registerCommand('azureStorage.generateSASUrl', generateSASUrl);
     registerCommand("azureStorage.attachStorageAccount", async (actionContext: IActionContext) => {
         await ext.attachedStorageAccountsTreeItem.attachWithConnectionString(actionContext);
     });

--- a/src/commands/storageAccountActionHandlers.ts
+++ b/src/commands/storageAccountActionHandlers.ts
@@ -12,6 +12,7 @@ import { ResolvedStorageAccount } from '../StorageAccountResolver';
 import { storageExplorerLauncher } from '../storageExplorerLauncher/storageExplorerLauncher';
 import { BlobContainerTreeItem } from "../tree/blob/BlobContainerTreeItem";
 import { ResolvedStorageAccountTreeItem, StorageAccountTreeItem } from '../tree/StorageAccountTreeItem';
+import { copyAndShowToast } from '../utils/copyAndShowToast';
 import { isPathEqual, isSubpath } from '../utils/fs';
 import { localize } from "../utils/localize";
 import { showWorkspaceFoldersQuickPick } from "../utils/quickPickUtils";
@@ -47,7 +48,7 @@ export async function copyPrimaryKey(context: IActionContext, treeItem?: Storage
         });
     }
 
-    await vscode.env.clipboard.writeText(treeItem.key.value);
+    await copyAndShowToast(treeItem.key.value, 'Primary key');
 }
 
 export async function copyConnectionString(context: IActionContext, treeItem?: StorageAccountTreeItem): Promise<void> {
@@ -59,7 +60,7 @@ export async function copyConnectionString(context: IActionContext, treeItem?: S
     }
 
     const connectionString = treeItem.getConnectionString();
-    await vscode.env.clipboard.writeText(connectionString);
+    await copyAndShowToast(connectionString, 'Connection string');
 }
 
 export async function deployStaticWebsite(context: IActionContext, target?: vscode.Uri | StorageAccountTreeItem | BlobContainerTreeItem): Promise<void> {

--- a/src/tree/IDownloadableTreeItem.ts
+++ b/src/tree/IDownloadableTreeItem.ts
@@ -1,0 +1,10 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IStorageTreeItem } from "./IStorageTreeItem";
+
+export interface IDownloadableTreeItem extends IStorageTreeItem {
+    remoteFilePath: string;
+}

--- a/src/tree/blob/BlobContainerTreeItem.ts
+++ b/src/tree/blob/BlobContainerTreeItem.ts
@@ -18,6 +18,7 @@ import { configurationSettingsKeys, getResourcesPath, NotificationProgress, stat
 import { ext } from "../../extensionVariables";
 import { TransferProgress } from '../../TransferProgress';
 import { createBlobContainerClient, createChildAsNewBlockBlob, IBlobContainerCreateChildContext, loadMoreBlobChildren } from '../../utils/blobUtils';
+import { copyAndShowToast } from '../../utils/copyAndShowToast';
 import { throwIfCanceled } from '../../utils/errorUtils';
 import { localize } from '../../utils/localize';
 import { getWorkspaceSetting } from '../../utils/settingsUtils';
@@ -175,9 +176,7 @@ export class BlobContainerTreeItem extends AzExtParentTreeItem implements ICopyU
 
     public async copyUrl(): Promise<void> {
         const url: string = this.getUrl();
-        await vscode.env.clipboard.writeText(url);
-        ext.outputChannel.show();
-        ext.outputChannel.appendLog(`Container URL copied to clipboard: ${url}`);
+        await copyAndShowToast(url, 'Container URL');
     }
 
     public async deployStaticWebsite(context: IActionContext, sourceFolderPath: string): Promise<void> {

--- a/src/tree/blob/BlobContainerTreeItem.ts
+++ b/src/tree/blob/BlobContainerTreeItem.ts
@@ -8,7 +8,6 @@ import * as azureStorageBlob from '@azure/storage-blob';
 import { AzExtParentTreeItem, AzExtTreeItem, DialogResponses, GenericTreeItem, IActionContext, ICreateChildImplContext, IParsedError, parseError, TelemetryProperties, UserCancelledError } from '@microsoft/vscode-azext-utils';
 import * as retry from 'p-retry';
 import * as path from 'path';
-import { posix } from 'path';
 import * as vscode from 'vscode';
 import { ProgressLocation, Uri } from 'vscode';
 import { AzureStorageFS } from '../../AzureStorageFS';
@@ -53,7 +52,7 @@ export class BlobContainerTreeItem extends AzExtParentTreeItem implements ICopyU
     }
 
     public get remoteFilePath(): string {
-        return `.${posix.sep}`;
+        return '';
     }
 
     public static async createBlobContainerTreeItem(parent: BlobContainerGroupTreeItem, container: azureStorageBlob.ContainerItem): Promise<BlobContainerTreeItem> {

--- a/src/tree/blob/BlobContainerTreeItem.ts
+++ b/src/tree/blob/BlobContainerTreeItem.ts
@@ -8,6 +8,7 @@ import * as azureStorageBlob from '@azure/storage-blob';
 import { AzExtParentTreeItem, AzExtTreeItem, DialogResponses, GenericTreeItem, IActionContext, ICreateChildImplContext, IParsedError, parseError, TelemetryProperties, UserCancelledError } from '@microsoft/vscode-azext-utils';
 import * as retry from 'p-retry';
 import * as path from 'path';
+import { posix } from 'path';
 import * as vscode from 'vscode';
 import { ProgressLocation, Uri } from 'vscode';
 import { AzureStorageFS } from '../../AzureStorageFS';
@@ -23,8 +24,8 @@ import { localize } from '../../utils/localize';
 import { getWorkspaceSetting } from '../../utils/settingsUtils';
 import { getUploadingMessageWithSource, uploadLocalFolder } from '../../utils/uploadUtils';
 import { ICopyUrl } from '../ICopyUrl';
+import { IDownloadableTreeItem } from '../IDownloadableTreeItem';
 import { IStorageRoot } from '../IStorageRoot';
-import { IStorageTreeItem } from '../IStorageTreeItem';
 import { isResolvedStorageAccountTreeItem, ResolvedStorageAccountTreeItem, StorageAccountTreeItem } from "../StorageAccountTreeItem";
 import { BlobContainerGroupTreeItem } from "./BlobContainerGroupTreeItem";
 import { BlobDirectoryTreeItem } from "./BlobDirectoryTreeItem";
@@ -35,7 +36,7 @@ export enum ChildType {
     uploadedBlob
 }
 
-export class BlobContainerTreeItem extends AzExtParentTreeItem implements ICopyUrl, IStorageTreeItem {
+export class BlobContainerTreeItem extends AzExtParentTreeItem implements ICopyUrl, IDownloadableTreeItem {
     private _continuationToken: string | undefined;
     private _websiteHostingEnabled: boolean;
     private _openInFileExplorerString: string = 'Open in Explorer...';
@@ -49,6 +50,10 @@ export class BlobContainerTreeItem extends AzExtParentTreeItem implements ICopyU
 
     public get root(): IStorageRoot {
         return this.parent.root;
+    }
+
+    public get remoteFilePath(): string {
+        return `.${posix.sep}`;
     }
 
     public static async createBlobContainerTreeItem(parent: BlobContainerGroupTreeItem, container: azureStorageBlob.ContainerItem): Promise<BlobContainerTreeItem> {

--- a/src/tree/blob/BlobDirectoryTreeItem.ts
+++ b/src/tree/blob/BlobDirectoryTreeItem.ts
@@ -10,6 +10,7 @@ import * as vscode from 'vscode';
 import { AzureStorageFS } from "../../AzureStorageFS";
 import { ext } from "../../extensionVariables";
 import { createBlobClient, createChildAsNewBlockBlob, IBlobContainerCreateChildContext, loadMoreBlobChildren } from '../../utils/blobUtils';
+import { copyAndShowToast } from "../../utils/copyAndShowToast";
 import { localize } from "../../utils/localize";
 import { ICopyUrl } from "../ICopyUrl";
 import { IDownloadableTreeItem } from "../IDownloadableTreeItem";
@@ -88,9 +89,7 @@ export class BlobDirectoryTreeItem extends AzExtParentTreeItem implements ICopyU
     public async copyUrl(): Promise<void> {
         const blobClient: azureStorageBlob.BlobClient = createBlobClient(this.root, this.container.name, this.dirPath);
         const url = blobClient.url;
-        await vscode.env.clipboard.writeText(url);
-        ext.outputChannel.show();
-        ext.outputChannel.appendLog(`Blob Directory URL copied to clipboard: ${url}`);
+        await copyAndShowToast(url, 'Blob Directory URL');
     }
 
     public async deleteTreeItemImpl(context: ISuppressMessageContext): Promise<void> {

--- a/src/tree/blob/BlobDirectoryTreeItem.ts
+++ b/src/tree/blob/BlobDirectoryTreeItem.ts
@@ -12,12 +12,12 @@ import { ext } from "../../extensionVariables";
 import { createBlobClient, createChildAsNewBlockBlob, IBlobContainerCreateChildContext, loadMoreBlobChildren } from '../../utils/blobUtils';
 import { localize } from "../../utils/localize";
 import { ICopyUrl } from "../ICopyUrl";
+import { IDownloadableTreeItem } from "../IDownloadableTreeItem";
 import { IStorageRoot } from "../IStorageRoot";
-import { IStorageTreeItem } from "../IStorageTreeItem";
 import { BlobContainerTreeItem } from "./BlobContainerTreeItem";
 import { BlobTreeItem, ISuppressMessageContext } from "./BlobTreeItem";
 
-export class BlobDirectoryTreeItem extends AzExtParentTreeItem implements ICopyUrl, IStorageTreeItem {
+export class BlobDirectoryTreeItem extends AzExtParentTreeItem implements ICopyUrl, IDownloadableTreeItem {
     public static contextValue: string = 'azureBlobDirectory';
     public contextValue: string = BlobDirectoryTreeItem.contextValue;
     public parent: BlobContainerTreeItem | BlobDirectoryTreeItem;
@@ -46,6 +46,10 @@ export class BlobDirectoryTreeItem extends AzExtParentTreeItem implements ICopyU
 
     public get root(): IStorageRoot {
         return this.parent.root;
+    }
+
+    public get remoteFilePath(): string {
+        return this.dirPath;
     }
 
     public get label(): string {

--- a/src/tree/blob/BlobTreeItem.ts
+++ b/src/tree/blob/BlobTreeItem.ts
@@ -11,9 +11,9 @@ import * as vscode from 'vscode';
 import { MessageItem, window } from 'vscode';
 import { AzureStorageFS } from "../../AzureStorageFS";
 import { storageExplorerDownloadUrl } from "../../constants";
-import { ext } from "../../extensionVariables";
 import { askOpenInStorageExplorer } from "../../utils/askOpenInStorageExplorer";
 import { createBlobClient, createBlockBlobClient } from '../../utils/blobUtils';
+import { copyAndShowToast } from "../../utils/copyAndShowToast";
 import { localize } from "../../utils/localize";
 import { ICopyUrl } from '../ICopyUrl';
 import { IDownloadableTreeItem } from "../IDownloadableTreeItem";
@@ -63,9 +63,7 @@ export class BlobTreeItem extends AzExtTreeItem implements ICopyUrl, IDownloadab
         // Use this.blobPath here instead of this.blobName. Otherwise the blob's containing directory/directories aren't displayed
         const blobClient: azureStorageBlob.BlobClient = createBlobClient(this.root, this.container.name, this.blobPath);
         const url = blobClient.url;
-        await vscode.env.clipboard.writeText(url);
-        ext.outputChannel.show();
-        ext.outputChannel.appendLog(`Blob URL copied to clipboard: ${url}`);
+        await copyAndShowToast(url, 'Blob URL');
     }
 
     public async deleteTreeItemImpl(context: ISuppressMessageContext): Promise<void> {

--- a/src/tree/blob/BlobTreeItem.ts
+++ b/src/tree/blob/BlobTreeItem.ts
@@ -16,12 +16,12 @@ import { askOpenInStorageExplorer } from "../../utils/askOpenInStorageExplorer";
 import { createBlobClient, createBlockBlobClient } from '../../utils/blobUtils';
 import { localize } from "../../utils/localize";
 import { ICopyUrl } from '../ICopyUrl';
+import { IDownloadableTreeItem } from "../IDownloadableTreeItem";
 import { IStorageRoot } from "../IStorageRoot";
-import { IStorageTreeItem } from "../IStorageTreeItem";
 import { BlobContainerTreeItem } from "./BlobContainerTreeItem";
 import { BlobDirectoryTreeItem } from "./BlobDirectoryTreeItem";
 
-export class BlobTreeItem extends AzExtTreeItem implements ICopyUrl, IStorageTreeItem {
+export class BlobTreeItem extends AzExtTreeItem implements ICopyUrl, IDownloadableTreeItem {
     public static contextValue: string = 'azureBlobFile';
     public contextValue: string = BlobTreeItem.contextValue;
     public parent: BlobContainerTreeItem | BlobDirectoryTreeItem;
@@ -45,6 +45,10 @@ export class BlobTreeItem extends AzExtTreeItem implements ICopyUrl, IStorageTre
 
     public get root(): IStorageRoot {
         return this.parent.root;
+    }
+
+    public get remoteFilePath(): string {
+        return this.blobPath;
     }
 
     public get label(): string {

--- a/src/tree/fileShare/DirectoryTreeItem.ts
+++ b/src/tree/fileShare/DirectoryTreeItem.ts
@@ -6,6 +6,7 @@
 import * as azureStorageShare from '@azure/storage-file-share';
 import { AzExtParentTreeItem, AzExtTreeItem, DialogResponses, IActionContext, ICreateChildImplContext, TreeItemIconPath, UserCancelledError } from '@microsoft/vscode-azext-utils';
 import * as path from 'path';
+import { posix } from 'path';
 import * as vscode from 'vscode';
 import { MessageItem, window } from 'vscode';
 import { AzureStorageFS } from "../../AzureStorageFS";
@@ -13,12 +14,12 @@ import { ext } from "../../extensionVariables";
 import { askAndCreateChildDirectory, deleteDirectoryAndContents, listFilesInDirectory } from '../../utils/directoryUtils';
 import { askAndCreateEmptyTextFile, createDirectoryClient } from '../../utils/fileUtils';
 import { ICopyUrl } from '../ICopyUrl';
+import { IDownloadableTreeItem } from '../IDownloadableTreeItem';
 import { IStorageRoot } from '../IStorageRoot';
-import { IStorageTreeItem } from '../IStorageTreeItem';
 import { FileShareTreeItem, IFileShareCreateChildContext } from "./FileShareTreeItem";
 import { FileTreeItem } from './FileTreeItem';
 
-export class DirectoryTreeItem extends AzExtParentTreeItem implements ICopyUrl, IStorageTreeItem {
+export class DirectoryTreeItem extends AzExtParentTreeItem implements ICopyUrl, IDownloadableTreeItem {
     public parent: FileShareTreeItem | DirectoryTreeItem;
     constructor(
         parent: FileShareTreeItem | DirectoryTreeItem,
@@ -35,6 +36,10 @@ export class DirectoryTreeItem extends AzExtParentTreeItem implements ICopyUrl, 
 
     public get root(): IStorageRoot {
         return this.parent.root;
+    }
+
+    public get remoteFilePath(): string {
+        return posix.join(this.parentPath, this.directoryName);
     }
 
     public get iconPath(): TreeItemIconPath {

--- a/src/tree/fileShare/DirectoryTreeItem.ts
+++ b/src/tree/fileShare/DirectoryTreeItem.ts
@@ -11,6 +11,7 @@ import * as vscode from 'vscode';
 import { MessageItem, window } from 'vscode';
 import { AzureStorageFS } from "../../AzureStorageFS";
 import { ext } from "../../extensionVariables";
+import { copyAndShowToast } from '../../utils/copyAndShowToast';
 import { askAndCreateChildDirectory, deleteDirectoryAndContents, listFilesInDirectory } from '../../utils/directoryUtils';
 import { askAndCreateEmptyTextFile, createDirectoryClient } from '../../utils/fileUtils';
 import { ICopyUrl } from '../ICopyUrl';
@@ -75,9 +76,7 @@ export class DirectoryTreeItem extends AzExtParentTreeItem implements ICopyUrl, 
         // Use this.fullPath here instead of this.directoryName. Otherwise only the leaf directory is displayed in the URL
         const directoryClient: azureStorageShare.ShareDirectoryClient = createDirectoryClient(this.root, this.shareName, this.fullPath);
         const url = directoryClient.url;
-        await vscode.env.clipboard.writeText(url);
-        ext.outputChannel.show();
-        ext.outputChannel.appendLog(`Directory URL copied to clipboard: ${url}`);
+        await copyAndShowToast(url, 'Directory URL');
     }
 
     public async createChildImpl(context: ICreateChildImplContext & IFileShareCreateChildContext): Promise<AzExtTreeItem> {

--- a/src/tree/fileShare/FileShareTreeItem.ts
+++ b/src/tree/fileShare/FileShareTreeItem.ts
@@ -7,6 +7,7 @@ import { ILocalLocation, IRemoteSasLocation } from '@azure-tools/azcopy-node';
 import * as azureStorageShare from '@azure/storage-file-share';
 import { AzExtParentTreeItem, AzExtTreeItem, DialogResponses, GenericTreeItem, IActionContext, ICreateChildImplContext, UserCancelledError } from '@microsoft/vscode-azext-utils';
 import * as path from 'path';
+import { posix } from 'path';
 import * as vscode from 'vscode';
 import { AzureStorageFS } from "../../AzureStorageFS";
 import { createAzCopyLocalLocation, createAzCopyRemoteLocation } from '../../commands/azCopy/azCopyLocations';
@@ -19,13 +20,13 @@ import { askAndCreateChildDirectory, doesDirectoryExist, listFilesInDirectory } 
 import { askAndCreateEmptyTextFile, createDirectoryClient, createShareClient } from '../../utils/fileUtils';
 import { getUploadingMessageWithSource } from '../../utils/uploadUtils';
 import { ICopyUrl } from '../ICopyUrl';
+import { IDownloadableTreeItem } from '../IDownloadableTreeItem';
 import { IStorageRoot } from '../IStorageRoot';
-import { IStorageTreeItem } from '../IStorageTreeItem';
 import { DirectoryTreeItem } from './DirectoryTreeItem';
 import { FileShareGroupTreeItem } from './FileShareGroupTreeItem';
 import { FileTreeItem } from './FileTreeItem';
 
-export class FileShareTreeItem extends AzExtParentTreeItem implements ICopyUrl, IStorageTreeItem {
+export class FileShareTreeItem extends AzExtParentTreeItem implements ICopyUrl, IDownloadableTreeItem {
     public parent: FileShareGroupTreeItem;
     private _continuationToken: string | undefined;
     private _openInFileExplorerString: string = 'Open in Explorer...';
@@ -42,6 +43,10 @@ export class FileShareTreeItem extends AzExtParentTreeItem implements ICopyUrl, 
 
     public get root(): IStorageRoot {
         return this.parent.root;
+    }
+
+    public get remoteFilePath(): string {
+        return `.${posix.sep}`;
     }
 
     public label: string = this.shareName;

--- a/src/tree/fileShare/FileShareTreeItem.ts
+++ b/src/tree/fileShare/FileShareTreeItem.ts
@@ -15,6 +15,7 @@ import { IExistingFileContext } from '../../commands/uploadFiles/IExistingFileCo
 import { getResourcesPath, NotificationProgress } from "../../constants";
 import { ext } from "../../extensionVariables";
 import { TransferProgress } from '../../TransferProgress';
+import { copyAndShowToast } from '../../utils/copyAndShowToast';
 import { askAndCreateChildDirectory, doesDirectoryExist, listFilesInDirectory } from '../../utils/directoryUtils';
 import { askAndCreateEmptyTextFile, createDirectoryClient, createShareClient } from '../../utils/fileUtils';
 import { getUploadingMessageWithSource } from '../../utils/uploadUtils';
@@ -98,9 +99,7 @@ export class FileShareTreeItem extends AzExtParentTreeItem implements ICopyUrl, 
 
     public async copyUrl(): Promise<void> {
         const url: string = this.getUrl();
-        await vscode.env.clipboard.writeText(url);
-        ext.outputChannel.show();
-        ext.outputChannel.appendLog(`Share URL copied to clipboard: ${url}`);
+        await copyAndShowToast(url, 'Share URL');
     }
 
     public async deleteTreeItemImpl(context: IActionContext): Promise<void> {

--- a/src/tree/fileShare/FileShareTreeItem.ts
+++ b/src/tree/fileShare/FileShareTreeItem.ts
@@ -7,7 +7,6 @@ import { ILocalLocation, IRemoteSasLocation } from '@azure-tools/azcopy-node';
 import * as azureStorageShare from '@azure/storage-file-share';
 import { AzExtParentTreeItem, AzExtTreeItem, DialogResponses, GenericTreeItem, IActionContext, ICreateChildImplContext, UserCancelledError } from '@microsoft/vscode-azext-utils';
 import * as path from 'path';
-import { posix } from 'path';
 import * as vscode from 'vscode';
 import { AzureStorageFS } from "../../AzureStorageFS";
 import { createAzCopyLocalLocation, createAzCopyRemoteLocation } from '../../commands/azCopy/azCopyLocations';
@@ -46,7 +45,7 @@ export class FileShareTreeItem extends AzExtParentTreeItem implements ICopyUrl, 
     }
 
     public get remoteFilePath(): string {
-        return `.${posix.sep}`;
+        return '';
     }
 
     public label: string = this.shareName;

--- a/src/tree/fileShare/FileTreeItem.ts
+++ b/src/tree/fileShare/FileTreeItem.ts
@@ -5,18 +5,19 @@
 
 import * as azureStorageShare from '@azure/storage-file-share';
 import { AzExtTreeItem, DialogResponses, IActionContext, TreeItemIconPath, UserCancelledError } from '@microsoft/vscode-azext-utils';
+import { posix } from 'path';
 import * as vscode from 'vscode';
 import { MessageItem, window } from 'vscode';
 import { AzureStorageFS } from "../../AzureStorageFS";
 import { ext } from "../../extensionVariables";
 import { createFileClient, deleteFile } from '../../utils/fileUtils';
 import { ICopyUrl } from '../ICopyUrl';
+import { IDownloadableTreeItem } from '../IDownloadableTreeItem';
 import { IStorageRoot } from '../IStorageRoot';
-import { IStorageTreeItem } from '../IStorageTreeItem';
 import { DirectoryTreeItem, IDirectoryDeleteContext } from "./DirectoryTreeItem";
 import { FileShareTreeItem } from './FileShareTreeItem';
 
-export class FileTreeItem extends AzExtTreeItem implements ICopyUrl, IStorageTreeItem {
+export class FileTreeItem extends AzExtTreeItem implements ICopyUrl, IDownloadableTreeItem {
     public parent: FileShareTreeItem | DirectoryTreeItem;
     constructor(
         parent: FileShareTreeItem | DirectoryTreeItem,
@@ -33,6 +34,10 @@ export class FileTreeItem extends AzExtTreeItem implements ICopyUrl, IStorageTre
 
     public get root(): IStorageRoot {
         return this.parent.root;
+    }
+
+    public get remoteFilePath(): string {
+        return posix.join(this.directoryPath, this.fileName);
     }
 
     public get iconPath(): TreeItemIconPath {

--- a/src/tree/fileShare/FileTreeItem.ts
+++ b/src/tree/fileShare/FileTreeItem.ts
@@ -9,7 +9,7 @@ import { posix } from 'path';
 import * as vscode from 'vscode';
 import { MessageItem, window } from 'vscode';
 import { AzureStorageFS } from "../../AzureStorageFS";
-import { ext } from "../../extensionVariables";
+import { copyAndShowToast } from '../../utils/copyAndShowToast';
 import { createFileClient, deleteFile } from '../../utils/fileUtils';
 import { ICopyUrl } from '../ICopyUrl';
 import { IDownloadableTreeItem } from '../IDownloadableTreeItem';
@@ -47,9 +47,7 @@ export class FileTreeItem extends AzExtTreeItem implements ICopyUrl, IDownloadab
     public async copyUrl(): Promise<void> {
         const fileClient: azureStorageShare.ShareFileClient = createFileClient(this.root, this.shareName, this.directoryPath, this.fileName);
         const url = fileClient.url;
-        await vscode.env.clipboard.writeText(url);
-        ext.outputChannel.show();
-        ext.outputChannel.appendLog(`File URL copied to clipboard: ${url}`);
+        await copyAndShowToast(url, 'File URL');
     }
 
     public async deleteTreeItemImpl(context: IActionContext & IDirectoryDeleteContext): Promise<void> {

--- a/src/utils/copyAndShowToast.ts
+++ b/src/utils/copyAndShowToast.ts
@@ -1,0 +1,14 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { env } from "vscode";
+import { ext } from "../extensionVariables";
+import { localize } from "./localize";
+
+export async function copyAndShowToast(text: string, name?: string): Promise<void> {
+    await env.clipboard.writeText(text);
+    ext.outputChannel.show();
+    ext.outputChannel.appendLog(localize('copiedClipboard', '{1} copied to clipboard: {0}', text, name));
+}

--- a/src/utils/uploadUtils.ts
+++ b/src/utils/uploadUtils.ts
@@ -16,6 +16,7 @@ import { BlobContainerTreeItem } from '../tree/blob/BlobContainerTreeItem';
 import { FileShareTreeItem } from '../tree/fileShare/FileShareTreeItem';
 import { doesBlobDirectoryExist, doesBlobExist } from './blobUtils';
 import { checkCanOverwrite } from './checkCanOverwrite';
+import { copyAndShowToast } from './copyAndShowToast';
 import { doesDirectoryExist } from './directoryUtils';
 import { doesFileExist } from './fileUtils';
 import { localize } from './localize';
@@ -67,9 +68,7 @@ export function outputAndCopyUploadedFileUrls(parentUrl: string, fileUrls: strin
         const shouldCopy: boolean = !!result;
         if (shouldCopy) {
             const lastFileUrl: string = `${parentUrl}/${fileUrls[fileUrls.length - 1]}`;
-            const success: string = localize('copiedToClipboard', 'File URL copied to clipboard: {0}', lastFileUrl);
-            await vscode.env.clipboard.writeText(lastFileUrl);
-            ext.outputChannel.appendLog(success);
+            await copyAndShowToast(lastFileUrl, 'File URL');
         }
     });
 }


### PR DESCRIPTION
Helps to address https://github.com/microsoft/vscode-azurestorage/issues/998

Specifically 
> A professor provides a link to a data file hosted in Blob Storage

This is something that [Storage Explorer](https://docs.microsoft.com/en-us/azure/cognitive-services/translator/document-translation/create-sas-tokens?tabs=Containers) already does, but the Portal's SAS token generation is lacking.  You can only generate a SAS url for the Blob Container or an individual file. If you paste the container url into the browser, nothing happens. The file url works for downloading in the browser.

File Shares are even worse. There is no SAS token generation. You can download a file by browsing to it in the portal, but it's definitely using a SAS token as well.

Technically, the SAS token can be appended to any file in the entire Storage Account (including other blob containers or file shares), but it's easier if we generate the url for them.

I added a `Generate & Copy SAS Token and URL` command for files and directories as well as Blob Containers and File Shares. The reason I added it to Blob Containers and File Shares as well is because AzCopy actually supports downloading an entire blob/file share if you pass `./` as the remote path, so I'd like to add support for downloading the entire container. 

However, the url you get from the portal doesn't include the `./` so we'll have to pass that into AzCopy whenever the download actually happens, or users won't be able to copy/paste the url from the portal without modification.

After this PR, I plan to add the following:
- Downloading a container or file share by right click
- Downloading a container, file share, directory, or file by passing in a SAS url
- Uploading a container, file share, directory, or file by passing in a SAS url

