### PR TITLE
Add local workspace support options to 'Create Queue' command via palette

### DIFF
--- a/src/commands/queue/queueGroupActionHandlers.ts
+++ b/src/commands/queue/queueGroupActionHandlers.ts
@@ -15,10 +15,6 @@ export function registerQueueGroupActionHandlers(): void {
 }
 
 export async function createQueue(context: IActionContext, node?: QueueGroupTreeItem): Promise<void> {
-    if (node?.root.isEmulated && !(await isAzuriteInstalled())) {
-        warnAzuriteNotInstalled(context);
-    }
-
     if (!node) {
         node = await ext.rgApi.pickAppResource<QueueGroupTreeItem>(context, {
             filter: storageFilter,
@@ -26,6 +22,10 @@ export async function createQueue(context: IActionContext, node?: QueueGroupTree
             workspaceRootContextValue: AttachedStorageAccountsTreeItem.contextValue,
             expectedWorkspaceContextValue: QueueGroupTreeItem.contextValue
         });
+    }
+
+    if (node.root.isEmulated && !(await isAzuriteInstalled())) {
+        warnAzuriteNotInstalled(context);
     }
 
     await node.createChild(context);

--- a/src/commands/queue/queueGroupActionHandlers.ts
+++ b/src/commands/queue/queueGroupActionHandlers.ts
@@ -4,17 +4,29 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IActionContext, registerCommand } from '@microsoft/vscode-azext-utils';
+import { storageFilter } from '../../constants';
+import { ext } from '../../extensionVariables';
+import { AttachedStorageAccountsTreeItem } from '../../tree/AttachedStorageAccountsTreeItem';
 import { QueueGroupTreeItem } from '../../tree/queue/QueueGroupTreeItem';
 import { isAzuriteInstalled, warnAzuriteNotInstalled } from '../../utils/azuriteUtils';
-import { createChildNode } from '../commonTreeCommands';
 
 export function registerQueueGroupActionHandlers(): void {
     registerCommand("azureStorage.createQueue", createQueue);
 }
 
-export async function createQueue(context: IActionContext, treeItem?: QueueGroupTreeItem): Promise<void> {
-    if (treeItem?.root.isEmulated && !(await isAzuriteInstalled())) {
+export async function createQueue(context: IActionContext, node?: QueueGroupTreeItem): Promise<void> {
+    if (node?.root.isEmulated && !(await isAzuriteInstalled())) {
         warnAzuriteNotInstalled(context);
     }
-    await createChildNode(context, QueueGroupTreeItem.contextValue, treeItem);
+
+    if (!node) {
+        node = await ext.rgApi.pickAppResource<QueueGroupTreeItem>(context, {
+            filter: storageFilter,
+            expectedChildContextValue: QueueGroupTreeItem.contextValue,
+            workspaceRootContextValue: AttachedStorageAccountsTreeItem.contextValue,
+            expectedWorkspaceContextValue: QueueGroupTreeItem.contextValue
+        });
+    }
+
+    await node.createChild(context);
 }

--- a/src/tree/AttachedStorageAccountsTreeItem.ts
+++ b/src/tree/AttachedStorageAccountsTreeItem.ts
@@ -20,7 +20,8 @@ interface IPersistedAccount {
 }
 
 export class AttachedStorageAccountsTreeItem extends AzExtParentTreeItem {
-    public readonly contextValue: string = 'attachedStorageAccounts';
+    public static readonly contextValue: string = 'attachedStorageAccounts';
+    public readonly contextValue: string = AttachedStorageAccountsTreeItem.contextValue;
     public readonly label: string = 'Attached Storage Accounts';
     public childTypeLabel: string = 'Account';
 


### PR DESCRIPTION
Fixes #1043 

I'm proposing to make changes to `pickAppResource` [here](https://github.com/microsoft/vscode-azureresourcegroups/pull/369) and [here](https://github.com/microsoft/vscode-azuretools/pull/1228).

Basically my change does this - when creating queue from the `command palette`, the new change will first ask if the node we are looking for is `remote` or `local`.  Based on this, we will either traverse the app resources or the workspace resources.

![Screen Shot 2022-08-22 at 10 28 47 AM](https://user-images.githubusercontent.com/40250218/185988262-33b24748-cd73-4d8c-8b0e-3618bb409c33.png)