### PR TITLE
Respect suppress notification setting when deleting blob directory

### DIFF
--- a/src/commands/deleteBlobDirectory/DeleteBlobDirectoryStep.ts
+++ b/src/commands/deleteBlobDirectory/DeleteBlobDirectoryStep.ts
@@ -35,7 +35,10 @@ export class DeleteBlobDirectoryStep extends AzureWizardExecuteStep<IDeleteBlobD
         }
         const deleteSuccessful: string = localize('successfullyDeletedBlobDirectory', 'Successfully deleted directory "{0}".', directoryName);
         ext.outputChannel.appendLog(deleteSuccessful);
-        void window.showInformationMessage(deleteSuccessful);
+
+        if (!wizardContext.suppressNotification) {
+            void window.showInformationMessage(deleteSuccessful);
+        }
     }
 
     public shouldExecute(): boolean {


### PR DESCRIPTION
We shouldn't show activity success messages as information messages when this setting is true (default).