### PR TITLE
Revert "Use new AzExtResourceType context values"

### DIFF
--- a/package.json
+++ b/package.json
@@ -327,12 +327,12 @@
             "view/item/context": [
                 {
                     "command": "azureStorage.createGpv2Account",
-                    "when": "view == azureResourceGroups && viewItem =~ /azureResourceTypeGroup/ && viewItem =~ /StorageAccounts/",
+                    "when": "view == azureResourceGroups && viewItem =~ /azureResourceTypeGroup.*microsoft.storage/storageaccounts/",
                     "group": "1@1"
                 },
                 {
                     "command": "azureStorage.createGpv2AccountAdvanced",
-                    "when": "view == azureResourceGroups && viewItem =~ /azureResourceTypeGroup/ && viewItem =~ /StorageAccounts/",
+                    "when": "view == azureResourceGroups && viewItem =~ /azureResourceTypeGroup.*microsoft.storage/storageaccounts/",
                     "group": "1@2"
                 },
                 {


### PR DESCRIPTION
This reverts commit bcab9fdff1a5718bd945f23f32cdf510824562ae.

Fixes #1131 

We will make this change again once RGs has been released.