### PR TITLE
Fixed issue found from downloading from a Sas url... code integration 

### DIFF
--- a/src/utils/uploadUtils.ts
+++ b/src/utils/uploadUtils.ts
@@ -57,7 +57,7 @@ export async function uploadLocalFolder(
 
     const resourceUri = getResourceUri(destTreeItem);
     const sasToken = getSasToken(destTreeItem.root);
-    const dst: IRemoteSasLocation = createAzCopyRemoteLocation(resourceUri, sasToken, destPath, true);
+    const dst: IRemoteSasLocation = createAzCopyRemoteLocation(resourceUri, sasToken, destPath, false);
     const transferProgress: TransferProgress = new TransferProgress('files', messagePrefix);
     ext.outputChannel.appendLog(getUploadingMessageWithSource(sourcePath, destTreeItem.label));
     await azCopyTransfer(context, fromTo, src, dst, transferProgress, notificationProgress, cancellationToken);


### PR DESCRIPTION
Found this issue while testing: 

When adding a folder to a blob container a sub directory called "*" was added. 

![image](https://user-images.githubusercontent.com/59709511/189446483-cffc9221-d3ba-4486-8ac4-9afd54cb437f.png)

Link to original PR: https://github.com/microsoft/vscode-azurestorage/pull/1151

