### PR TITLE
Fix the regExp that matches the id of the tree item

### DIFF
--- a/src/AzureStorageFS.ts
+++ b/src/AzureStorageFS.ts
@@ -43,7 +43,7 @@ export class AzureStorageFS implements vscode.FileSystemProvider, vscode.TextDoc
         if (resourceId.startsWith('/attachedStorageAccounts')) {
             idRegExp = /(\/attachedStorageAccounts\/[^\/]+\/[^\/]+\/[^\/]+)\/?(.*)/i;
         } else {
-            idRegExp = /(\/subscriptions\/[^\/]+\/[^\/]+\/[^\/]+\/subscriptions\/[^\/]+\/resourceGroups\/[^\/]+\/providers\/Microsoft.Storage\/storageAccounts\/[^\/]+\/[^\/]+\/[^\/]+)\/?(.*)/i;
+            idRegExp = /(\/subscriptions\/[^\/]+\/[^\/]+\/subscriptions\/[^\/]+\/resourceGroups\/[^\/]+\/providers\/Microsoft.Storage\/storageAccounts\/[^\/]+\/[^\/]+\/[^\/]+)\/?(.*)/i;
         }
 
         let matches: RegExpMatchArray | null = resourceId.match(idRegExp);


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azureresourcegroups/issues/377

Due to https://github.com/microsoft/vscode-azureresourcegroups/commit/17033f24577c52ba19af7188f5169f598423b6ee, the id of the GroupTreeItems changed on every Azure Group Tree Item.  That changed the form of expected id, which AzureStorageFS needs to look up tree items in the tree view.

This is changing the regexp to match the new expected id form.