### PR TITLE
Use wildcard regex instead of exact format of id

### DIFF
--- a/src/AzureStorageFS.ts
+++ b/src/AzureStorageFS.ts
@@ -43,7 +43,7 @@ export class AzureStorageFS implements vscode.FileSystemProvider, vscode.TextDoc
         if (resourceId.startsWith('/attachedStorageAccounts')) {
             idRegExp = /(\/attachedStorageAccounts\/[^\/]+\/[^\/]+\/[^\/]+)\/?(.*)/i;
         } else {
-            idRegExp = /(\/subscriptions\/[^\/]+\/[^\/]+\/subscriptions\/[^\/]+\/resourceGroups\/[^\/]+\/providers\/Microsoft.Storage\/storageAccounts\/[^\/]+\/[^\/]+\/[^\/]+)\/?(.*)/i;
+            idRegExp = /(\/subscriptions\/.*\/subscriptions\/[^\/]+\/resourceGroups\/[^\/]+\/providers\/Microsoft.Storage\/storageAccounts\/[^\/]+\/[^\/]+\/[^\/]+)\/?(.*)/i;
         }
 
         let matches: RegExpMatchArray | null = resourceId.match(idRegExp);


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurestorage/issues/1162

Since the format of our ID changes depending on the grouping (resource type, resource group, etc.), I think it's safer to just use a wildcard capture on it. There's still quite a bit of safety since the rest of the id has to match, and that format is pretty specific. It is just wildcarding the group portion of the id.

This happened because the ids for group typing used to be `provider/type.kind` but got switched to just `AzExtResourceType`.