### PR TITLE
Add activity context to downloadFiles wizard

### DIFF
--- a/src/commands/downloadFile.ts
+++ b/src/commands/downloadFile.ts
@@ -6,6 +6,7 @@
 import { FromToOption } from "@azure-tools/azcopy-node";
 import { AzureWizard, AzureWizardPromptStep, IActionContext } from "@microsoft/vscode-azext-utils";
 import { IDownloadableTreeItem } from "../tree/IDownloadableTreeItem";
+import { createActivityContext } from "../utils/activityUtils";
 import { localize } from "../utils/localize";
 import { DestinationPromptStep } from "./downloadFiles/DestinationPromptStep";
 import { DownloadFilesStep } from "./downloadFiles/DownloadFilesStep";
@@ -23,15 +24,16 @@ export interface IAzCopyDownload {
     sasToken: string;
 }
 
-export async function download(context: IDownloadWizardContext, treeItems?: IDownloadableTreeItem[]): Promise<void> {
+export async function download(context: IActionContext, treeItems?: IDownloadableTreeItem[]): Promise<void> {
+    const wizardContext: IDownloadWizardContext = { ...context, ...(await createActivityContext()) };
     const promptSteps: AzureWizardPromptStep<IDownloadWizardContext>[] = [new DestinationPromptStep()];
     if (!treeItems) {
         promptSteps.push(new SasUrlPromptStep());
     } else {
-        context.treeItems = treeItems;
+        wizardContext.treeItems = treeItems;
     }
 
-    const wizard: AzureWizard<IDownloadWizardContext> = new AzureWizard(context, {
+    const wizard: AzureWizard<IDownloadWizardContext> = new AzureWizard(wizardContext, {
         promptSteps,
         executeSteps: [new GetAzCopyDownloadsStep(), new DownloadFilesStep()],
         title: localize('download', 'Download Files')

--- a/src/commands/downloadFiles/DownloadFilesStep.ts
+++ b/src/commands/downloadFiles/DownloadFilesStep.ts
@@ -34,6 +34,7 @@ export class DownloadFilesStep extends AzureWizardExecuteStep<IDownloadWizardCon
         }
 
         const message: string = localize('downloadingTo', 'Downloading to "{0}"...', context.destinationFolder);
+        context.activityTitle = message;
         ext.outputChannel.appendLog(message);
         progress.report({ message });
 
@@ -48,7 +49,8 @@ export class DownloadFilesStep extends AzureWizardExecuteStep<IDownloadWizardCon
             }
         }
 
-        const downloaded: string = localize('successfullyDownloaded', 'Successfully downloaded to "{0}".', context.destinationFolder);
+        const downloaded: string = localize('successfullyDownloaded', 'Downloaded to "{0}".', context.destinationFolder);
+        context.activityTitle = downloaded;
         progress.report({ message: downloaded });
         ext.outputChannel.appendLog(downloaded);
     }

--- a/src/commands/downloadFiles/IDownloadWizardContext.ts
+++ b/src/commands/downloadFiles/IDownloadWizardContext.ts
@@ -3,11 +3,11 @@
 *  Licensed under the MIT License. See License.txt in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
-import { IActionContext } from "@microsoft/vscode-azext-utils";
+import { ExecuteActivityContext, IActionContext } from "@microsoft/vscode-azext-utils";
 import { IDownloadableTreeItem } from "../../tree/IDownloadableTreeItem";
 import { IAzCopyDownload } from "../downloadFile";
 
-export interface IDownloadWizardContext extends IActionContext {
+export interface IDownloadWizardContext extends IActionContext, ExecuteActivityContext {
     destinationFolder?: string;
     sasUrl?: string;
     treeItems?: IDownloadableTreeItem[];
@@ -15,3 +15,4 @@ export interface IDownloadWizardContext extends IActionContext {
     allFileDownloads?: IAzCopyDownload[];
     allFolderDownloads?: IAzCopyDownload[];
 }
+

--- a/src/commands/downloadFiles/IDownloadWizardContext.ts
+++ b/src/commands/downloadFiles/IDownloadWizardContext.ts
@@ -15,4 +15,3 @@ export interface IDownloadWizardContext extends IActionContext, ExecuteActivityC
     allFileDownloads?: IAzCopyDownload[];
     allFolderDownloads?: IAzCopyDownload[];
 }
-


### PR DESCRIPTION
Closes #1163 

Added an activity context to the Azure Wizard for downloading files.  As per our standup discussion, wiring this up to the activity log will serve as the notification for completion of the download activity instead of an information window pop-up.  We can expand upon this implementation if we find more information needs to be displayed later.