### PR TITLE
Replace `Copy to Clipboard` with `View Output` for uploading multiple files

### DIFF
--- a/src/utils/uploadUtils.ts
+++ b/src/utils/uploadUtils.ts
@@ -77,16 +77,33 @@ export function outputAndCopyUploadedFileUrls(parentUrl: string, fileUrls: strin
         ext.outputChannel.appendLog(url);
     }
 
-    void vscode.window.showInformationMessage(
-        localize('outputAndCopyFinished', 'Finished uploading {0} {1}.', fileUrls.length, fileUrls.length === 1 ? 'file' : 'files'),
-        localize('copyToClipboard', 'Copy to Clipboard')
-    ).then(async (result) => {
-        const shouldCopy: boolean = !!result;
-        if (shouldCopy) {
-            const lastFileUrl: string = `${parentUrl}/${fileUrls[fileUrls.length - 1]}`;
-            await copyAndShowToast(lastFileUrl, 'File URL');
-        }
-    });
+    const copyToClipboard: string = localize('copyToClipboard', 'Copy to Clipboard');
+    const outputAndCopyFile: string = localize('outputAndCopyFinished.file', 'Finished uploading 1 file.');
+    const outputAndCopyFiles: string = localize('outputAndCopyFinished.files', 'Finished uploading {0} files.', fileUrls.length);
+    const viewOutput: string = localize('viewOutput', 'View Output');
+
+    if (fileUrls.length === 1) {
+        void vscode.window.showInformationMessage(
+            outputAndCopyFile,
+            copyToClipboard
+        ).then(async (result) => {
+            const shouldCopy: boolean = !!result;
+            if (shouldCopy) {
+                const lastFileUrl: string = `${parentUrl}/${fileUrls[fileUrls.length - 1]}`;
+                await copyAndShowToast(lastFileUrl, 'File URL');
+            }
+        });
+    } else {
+        void vscode.window.showInformationMessage(
+            outputAndCopyFiles,
+            viewOutput
+        ).then(async (result) => {
+            const shouldView: boolean = !!result;
+            if (shouldView) {
+                ext.outputChannel.show();
+            }
+        });
+    }
 }
 
 export function showUploadSuccessMessage(treeItemLabel: string): void {


### PR DESCRIPTION
Closes #1164 

These toasts/information message windows should eventually be replaced with informational/commandId Activity Log children.  For now, for the case of uploading multiple files, instead of providing a copy button, we can just show an option to view output.

Let me know what you guys think!  I thought removing informational boxes entirely would look too minimal without full implementation of the activity log children.