### PR TITLE
Intentionally override base property

### DIFF
--- a/src/tree/table/TableGroupTreeItem.ts
+++ b/src/tree/table/TableGroupTreeItem.ts
@@ -24,7 +24,7 @@ export class TableGroupTreeItem extends AzExtParentTreeItem implements IStorageT
     public readonly childTypeLabel: string = "Table";
     public static contextValue: string = 'azureTableGroup';
     public contextValue: string = TableGroupTreeItem.contextValue;
-    public parent: (ResolvedAppResourceTreeItem<ResolvedStorageAccount> & AzExtParentTreeItem) | AttachedStorageAccountTreeItem;
+    public declare parent: (ResolvedAppResourceTreeItem<ResolvedStorageAccount> & AzExtParentTreeItem) | AttachedStorageAccountTreeItem;
 
     public constructor(parent: (ResolvedAppResourceTreeItem<ResolvedStorageAccount> & AzExtParentTreeItem) | AttachedStorageAccountTreeItem) {
         super(parent);


### PR DESCRIPTION
Fixes this TS error:

`
Property 'parent' will overwrite the base property in 'AzExtParentTreeItem'. If this is intentional, add an initializer. Otherwise, add a 'declare' modifier or remove the redundant declaration.ts(2612)
`