### PR TITLE
Fix delete storage account from palette

### DIFF
--- a/src/commands/commonTreeCommands.ts
+++ b/src/commands/commonTreeCommands.ts
@@ -7,7 +7,7 @@ import { AzExtParentTreeItem, AzExtTreeItem, IActionContext } from '@microsoft/v
 import { storageFilter } from '../constants';
 import { ext } from '../extensionVariables';
 
-export async function deleteNode(context: IActionContext, expectedContextValue: string | RegExp, node?: AzExtTreeItem): Promise<void> {
+export async function deleteNode(context: IActionContext, expectedContextValue?: string | RegExp, node?: AzExtTreeItem): Promise<void> {
     if (!node) {
         node = await ext.rgApi.pickAppResource({ ...context, suppressCreatePick: true }, {
             filter: storageFilter,

--- a/src/commands/storageAccountActionHandlers.ts
+++ b/src/commands/storageAccountActionHandlers.ts
@@ -136,7 +136,7 @@ function isTaskEqual(expectedName: string, expectedPath: string, actualTask: vsc
 }
 
 export async function deleteStorageAccount(context: IActionContext, treeItem?: StorageAccountTreeItem & AzExtTreeItem): Promise<void> {
-    await deleteNode(context, new RegExp(StorageAccountTreeItem.contextValue), treeItem);
+    await deleteNode(context, undefined, treeItem);
 }
 
 async function pickStorageAccount(context: IActionContext) {


### PR DESCRIPTION
If you're picking a top level Azure resource, you cannot pass in an expected child context value. The compat API doesn't support this.

I think this was a mistake made in v1, but v1 just so happen to be fine with it. We need to make sure we don't do this in v1.5.

Fixes #1202 