### PR TITLE
Create different "Install azcopy" steps based on OS Agent

### DIFF
--- a/.azure-pipelines/common/package.yml
+++ b/.azure-pipelines/common/package.yml
@@ -1,41 +1,38 @@
 steps:
-  - bash: npm install --force @azure-tools/azcopy-darwin \
-      chmod u+x node_modules/@azure-tools/azcopy-darwin/dist/bin/azcopy_darwin_amd64
-    displayName: "Install azcopy (MacOS)"
-    condition: eq(variables['Agent.OS'], 'Darwin')
+- bash: npm install --force @azure-tools/azcopy-darwin \
+    chmod u+x node_modules/@azure-tools/azcopy-darwin/dist/bin/azcopy_darwin_amd64
+  displayName: 'Install azcopy (MacOS)'
 
-  - bash: npm install --force @azure-tools/azcopy-linux \
-      chmod u+x node_modules/@azure-tools/azcopy-linux/dist/bin/azcopy_linux_amd64
-    displayName: "Install azcopy (Linux)"
-    condition: eq(variables['Agent.OS'], 'Linux')
+- bash: npm install --force @azure-tools/azcopy-linux \
+    chmod u+x node_modules/@azure-tools/azcopy-linux/dist/bin/azcopy_linux_amd64
+  displayName: 'Install azcopy (Linux)'
 
-  - bash: npm install --force @azure-tools/azcopy-win32 \
+- bash: npm install --force @azure-tools/azcopy-win32 \
       @azure-tools/azcopy-win64
-    displayName: "Install azcopy (Windows)"
-    condition: eq(variables['Agent.OS'], 'Windows_NT')
+  displayName: 'Install azcopy (Windows)'
 
-  - task: Npm@1
-    displayName: "cleanReadme"
-    inputs:
-      command: custom
-      customCommand: run cleanReadme
+- task: Npm@1
+  displayName: 'cleanReadme'
+  inputs:
+    command: custom
+    customCommand: run cleanReadme
 
-  - task: Npm@1
-    displayName: "Package"
-    inputs:
-      command: custom
-      customCommand: run package
+- task: Npm@1
+  displayName: 'Package'
+  inputs:
+    command: custom
+    customCommand: run package
 
-  - task: CopyFiles@2
-    displayName: "Copy vsix to staging directory"
-    inputs:
-      Contents: "**/*.vsix"
-      TargetFolder: "$(build.artifactstagingdirectory)"
+- task: CopyFiles@2
+  displayName: 'Copy vsix to staging directory'
+  inputs:
+    Contents: '**/*.vsix'
+    TargetFolder: '$(build.artifactstagingdirectory)'
 
-  - task: PublishBuildArtifacts@1
-    displayName: "Publish artifacts: vsix"
-    inputs:
-      PathtoPublish: "$(build.artifactstagingdirectory)"
-      ArtifactName: vsix
-    # Only publish vsix from linux build since we use this to release and want to stay consistent
-    condition: and(eq(variables['Agent.OS'], 'Linux'), ne(variables['System.PullRequest.IsFork'], 'True'))
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish artifacts: vsix'
+  inputs:
+    PathtoPublish: '$(build.artifactstagingdirectory)'
+    ArtifactName: vsix
+  # Only publish vsix from linux build since we use this to release and want to stay consistent
+  condition: and(eq(variables['Agent.OS'], 'Linux'), ne(variables['System.PullRequest.IsFork'], 'True'))

--- a/.azure-pipelines/common/package.yml
+++ b/.azure-pipelines/common/package.yml
@@ -1,15 +1,18 @@
 steps:
-- bash: npm install --force @azure-tools/azcopy-darwin
+- bash: |
+    npm install --force @azure-tools/azcopy-darwin
     chmod u+x node_modules/@azure-tools/azcopy-darwin/dist/bin/azcopy_darwin_amd64
   displayName: 'Install azcopy (MacOS)'
   condition: eq(variables['Agent.OS'], 'Darwin')
 
-- bash: npm install --force @azure-tools/azcopy-linux
+- bash: |
+    npm install --force @azure-tools/azcopy-linux
     chmod u+x node_modules/@azure-tools/azcopy-linux/dist/bin/azcopy_linux_amd64
   displayName: 'Install azcopy (Linux)'
   condition: eq(variables['Agent.OS'], 'Linux')
 
-- bash: npm install --force @azure-tools/azcopy-win32 \
+- bash: |
+    npm install --force @azure-tools/azcopy-win32 \
       @azure-tools/azcopy-win64
   displayName: 'Install azcopy (Windows)'
   condition: eq(variables['Agent.OS'], 'Windows_NT')

--- a/.azure-pipelines/common/package.yml
+++ b/.azure-pipelines/common/package.yml
@@ -1,35 +1,41 @@
 steps:
-- bash: |
-    npm install --force @azure-tools/azcopy-darwin \
-      @azure-tools/azcopy-linux \
-      @azure-tools/azcopy-win32 \
+  - bash: npm install --force @azure-tools/azcopy-darwin
+      chmod u+x node_modules/@azure-tools/azcopy-darwin/dist/bin/azcopy_darwin_amd64
+    displayName: "Install azcopy (MacOS)"
+    condition: eq(variables['Agent.OS'], 'macOS')
+
+  - bash: npm install --force @azure-tools/azcopy-linux
+      chmod u+x node_modules/@azure-tools/azcopy-linux/dist/bin/azcopy_linux_amd64
+    displayName: "Install azcopy (Linux)"
+    condition: eq(variables['Agent.OS'], 'Linux')
+
+  - bash: npm install --force @azure-tools/azcopy-win32 \
       @azure-tools/azcopy-win64
-    chmod u+x node_modules/@azure-tools/azcopy-darwin/dist/bin/azcopy_darwin_amd64 \
-      node_modules/@azure-tools/azcopy-linux/dist/bin/azcopy_linux_amd64
-  displayName: 'Install azcopy'
+    displayName: "Install azcopy (Windows)"
+    condition: eq(variables['Agent.OS'], 'Windows')
 
-- task: Npm@1
-  displayName: 'cleanReadme'
-  inputs:
-    command: custom
-    customCommand: run cleanReadme
+  - task: Npm@1
+    displayName: "cleanReadme"
+    inputs:
+      command: custom
+      customCommand: run cleanReadme
 
-- task: Npm@1
-  displayName: 'Package'
-  inputs:
-    command: custom
-    customCommand: run package
+  - task: Npm@1
+    displayName: "Package"
+    inputs:
+      command: custom
+      customCommand: run package
 
-- task: CopyFiles@2
-  displayName: 'Copy vsix to staging directory'
-  inputs:
-    Contents: '**/*.vsix'
-    TargetFolder: '$(build.artifactstagingdirectory)'
+  - task: CopyFiles@2
+    displayName: "Copy vsix to staging directory"
+    inputs:
+      Contents: "**/*.vsix"
+      TargetFolder: "$(build.artifactstagingdirectory)"
 
-- task: PublishBuildArtifacts@1
-  displayName: 'Publish artifacts: vsix'
-  inputs:
-    PathtoPublish: '$(build.artifactstagingdirectory)'
-    ArtifactName: vsix
-  # Only publish vsix from linux build since we use this to release and want to stay consistent
-  condition: and(eq(variables['Agent.OS'], 'Linux'), ne(variables['System.PullRequest.IsFork'], 'True'))
+  - task: PublishBuildArtifacts@1
+    displayName: "Publish artifacts: vsix"
+    inputs:
+      PathtoPublish: "$(build.artifactstagingdirectory)"
+      ArtifactName: vsix
+    # Only publish vsix from linux build since we use this to release and want to stay consistent
+    condition: and(eq(variables['Agent.OS'], 'Linux'), ne(variables['System.PullRequest.IsFork'], 'True'))

--- a/.azure-pipelines/common/package.yml
+++ b/.azure-pipelines/common/package.yml
@@ -1,15 +1,18 @@
 steps:
-- bash: npm install --force @azure-tools/azcopy-darwin \
+- bash: npm install --force @azure-tools/azcopy-darwin
     chmod u+x node_modules/@azure-tools/azcopy-darwin/dist/bin/azcopy_darwin_amd64
   displayName: 'Install azcopy (MacOS)'
+  condition: eq(variables['Agent.OS'], 'Darwin')
 
-- bash: npm install --force @azure-tools/azcopy-linux \
+- bash: npm install --force @azure-tools/azcopy-linux
     chmod u+x node_modules/@azure-tools/azcopy-linux/dist/bin/azcopy_linux_amd64
   displayName: 'Install azcopy (Linux)'
+  condition: eq(variables['Agent.OS'], 'Linux')
 
 - bash: npm install --force @azure-tools/azcopy-win32 \
       @azure-tools/azcopy-win64
   displayName: 'Install azcopy (Windows)'
+  condition: eq(variables['Agent.OS'], 'Windows_NT')
 
 - task: Npm@1
   displayName: 'cleanReadme'

--- a/.azure-pipelines/common/package.yml
+++ b/.azure-pipelines/common/package.yml
@@ -1,10 +1,10 @@
 steps:
-  - bash: npm install --force @azure-tools/azcopy-darwin
+  - bash: npm install --force @azure-tools/azcopy-darwin \
       chmod u+x node_modules/@azure-tools/azcopy-darwin/dist/bin/azcopy_darwin_amd64
     displayName: "Install azcopy (MacOS)"
-    condition: eq(variables['Agent.OS'], 'macOS')
+    condition: eq(variables['Agent.OS'], 'Darwin')
 
-  - bash: npm install --force @azure-tools/azcopy-linux
+  - bash: npm install --force @azure-tools/azcopy-linux \
       chmod u+x node_modules/@azure-tools/azcopy-linux/dist/bin/azcopy_linux_amd64
     displayName: "Install azcopy (Linux)"
     condition: eq(variables['Agent.OS'], 'Linux')
@@ -12,7 +12,7 @@ steps:
   - bash: npm install --force @azure-tools/azcopy-win32 \
       @azure-tools/azcopy-win64
     displayName: "Install azcopy (Windows)"
-    condition: eq(variables['Agent.OS'], 'Windows')
+    condition: eq(variables['Agent.OS'], 'Windows_NT')
 
   - task: Npm@1
     displayName: "cleanReadme"


### PR DESCRIPTION
The builds were breaking whenever `npm list --production --parseable --depth=99999 --loglevel=error` ran. This was because forcing azcopy to install on an OS it doesn't support was throwing invalid errors. 

For example, this is for Windows:

```
npm ERR! code ELSPROBLEMS
> vscode-azurestorage@0.15.4-alpha.0 package
npm ERR! invalid: @azure-tools/azcopy-darwin@10.19.0 D:\a\1\s\node_modules\@azure-tools\azcopy-darwin
> vsce package --githubBranch main
npm ERR! invalid: @azure-tools/azcopy-linux@10.19.0 D:\a\1\s\node_modules\@azure-tools\azcopy-linux
```