### PR TITLE
Create transfer-tech agnostic functions for upload

### DIFF
--- a/src/commands/downloadFile.ts
+++ b/src/commands/downloadFile.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { FromToOption } from "@azure-tools/azcopy-node";
 import { AzureWizard, AzureWizardPromptStep, IActionContext } from "@microsoft/vscode-azext-utils";
 import { ITransferSrcOrDstTreeItem } from "../tree/ITransferSrcOrDstTreeItem";
 import { createActivityContext } from "../utils/activityUtils";
@@ -18,7 +17,6 @@ export interface IAzCopyDownload {
     remoteFileName: string;
     remoteFilePath: string;
     localFilePath: string;
-    fromTo: FromToOption;
     isDirectory: boolean;
     resourceUri: string;
     sasToken: string;

--- a/src/commands/downloadFiles/DownloadFilesStep.ts
+++ b/src/commands/downloadFiles/DownloadFilesStep.ts
@@ -16,8 +16,8 @@ export class DownloadFilesStep extends AzureWizardExecuteStep<IDownloadWizardCon
         super();
     }
 
-    public async execute(context: IDownloadWizardContext, progress: NotificationProgress): Promise<void> {
-        await downloadFoldersAndFiles(context, progress, context.allFolderDownloads ?? [], context.allFileDownloads ?? [], this.cancellationToken);
+    public async execute(context: IDownloadWizardContext, notificationProgress: NotificationProgress): Promise<void> {
+        await downloadFoldersAndFiles(context, context.allFolderDownloads ?? [], context.allFileDownloads ?? [], notificationProgress, this.cancellationToken);
     }
 
     public shouldExecute(wizardContext: IDownloadWizardContext): boolean {

--- a/src/commands/transfers/transfers.ts
+++ b/src/commands/transfers/transfers.ts
@@ -111,6 +111,7 @@ function okToOverwriteOrDoesNotExist(context: IActionContext, item: DownloadItem
 }
 
 async function startAzCopyDownload(context: IDownloadWizardContext, item: DownloadItem, progress?: NotificationProgress, cancellationToken?: CancellationToken): Promise<void> {
+    // Import AzCopy packages with async import to avoid loading them in runtimes that don't support AzCopy.
     const { azCopyTransfer } = await import("./azCopy/azCopyTransfer");
     const { createAzCopyLocalLocation, createAzCopyRemoteLocation } = await import("./azCopy/azCopyLocations");
 
@@ -126,6 +127,7 @@ async function startAzCopyDownload(context: IDownloadWizardContext, item: Downlo
 }
 
 async function startAzCopyFileUpload(context: IActionContext, item: UploadItem, notificationProgress?: NotificationProgress, cancellationToken?: CancellationToken) {
+    // Import AzCopy packages with async import to avoid loading them in runtimes that don't support AzCopy.
     const { azCopyTransfer } = await import("./azCopy/azCopyTransfer");
     const { createAzCopyLocalLocation, createAzCopyRemoteLocation } = await import("./azCopy/azCopyLocations");
 
@@ -136,6 +138,7 @@ async function startAzCopyFileUpload(context: IActionContext, item: UploadItem, 
 }
 
 async function startAzCopyFolderUpload(context: IActionContext, item: UploadItem, messagePrefix?: string, notificationProgress?: NotificationProgress, cancellationToken?: CancellationToken): Promise<void> {
+    // Import AzCopy packages with async import to avoid loading them in runtimes that don't support AzCopy.
     const { azCopyTransfer } = await import("./azCopy/azCopyTransfer");
     const { createAzCopyLocalLocation, createAzCopyRemoteLocation } = await import("./azCopy/azCopyLocations");
 

--- a/src/commands/transfers/transfers.ts
+++ b/src/commands/transfers/transfers.ts
@@ -6,14 +6,15 @@
 import type { FromToOption, ILocalLocation, IRemoteSasLocation } from "@azure-tools/azcopy-node";
 
 import { AzExtFsExtra, IActionContext } from "@microsoft/vscode-azext-utils";
+import { dirname } from "path";
 import { CancellationToken } from "vscode";
 import { TransferProgress } from "../../TransferProgress";
 import { NotificationProgress } from "../../constants";
 import { ext } from "../../extensionVariables";
 import { checkCanOverwrite } from "../../utils/checkCanOverwrite";
-import { isSubpath } from "../../utils/fs";
+import { isEmptyDirectory, isSubpath } from "../../utils/fs";
 import { localize } from "../../utils/localize";
-import { OverwriteChoice } from "../../utils/uploadUtils";
+import { OverwriteChoice, getUploadingMessageWithSource } from "../../utils/uploadUtils";
 import { IDownloadWizardContext } from "../downloadFiles/IDownloadWizardContext";
 
 export type DownloadItem = {
@@ -26,7 +27,7 @@ export type DownloadItem = {
     sasToken: string;
 }
 
-export async function downloadFoldersAndFiles(context: IDownloadWizardContext, progress: NotificationProgress, folders: DownloadItem[], files: DownloadItem[], cancellationToken?: CancellationToken): Promise<void> {
+export async function downloadFoldersAndFiles(context: IDownloadWizardContext, folders: DownloadItem[], files: DownloadItem[], notificationProgress?: NotificationProgress, cancellationToken?: CancellationToken): Promise<void> {
     const overwriteChoice: { choice: OverwriteChoice | undefined } = { choice: undefined };
 
     const foldersToDownload = (await Promise.all(folders
@@ -41,29 +42,51 @@ export async function downloadFoldersAndFiles(context: IDownloadWizardContext, p
 
     const itemsToDownload = foldersToDownload.concat(filesToDownload);
     if (itemsToDownload.length > 0) {
-        const message: string = localize('downloadingTo', 'Downloading to "{0}"...', context.destinationFolder);
-        context.activityTitle = message;
-        ext.outputChannel.appendLog(message);
-        progress.report({ message });
+        const inProgressMessage: string = localize('downloadingTo', 'Downloading to "{0}"...', context.destinationFolder);
+        context.activityTitle = inProgressMessage;
+        ext.outputChannel.appendLog(inProgressMessage);
+        notificationProgress?.report({ message: inProgressMessage });
 
         for (const item of itemsToDownload) {
-            // @todo: add if/else for vscode.dev code path
-            await startAzCopyDownload(context, progress, item, cancellationToken);
+            if (!ext.isWeb) {
+                // @todo: add code path for isWeb === true
+                await startAzCopyDownload(context, item, notificationProgress, cancellationToken);
+            }
         }
 
-        const downloaded: string = localize('successfullyDownloaded', 'Downloaded to "{0}".', context.destinationFolder);
-        context.activityTitle = downloaded;
-        progress.report({ message: downloaded });
-        ext.outputChannel.appendLog(downloaded);
+        const downloadedMessage: string = localize('successfullyDownloaded', 'Downloaded to "{0}".', context.destinationFolder);
+        context.activityTitle = downloadedMessage;
+        notificationProgress?.report({ message: downloadedMessage });
+        ext.outputChannel.appendLog(downloadedMessage);
     }
 }
 
-export async function uploadFiles(): Promise<void> {
-    // @todo
+export type UploadItem = {
+    type: "blob" | "file";
+    localFilePath: string;
+    resourceName: string;
+    resourceUri: string;
+    remoteFilePath: string;
+    transferSasToken: string;
 }
 
-export async function uploadFolders(): Promise<void> {
-    // @todo
+export async function uploadFile(context: IActionContext, item: UploadItem, notificationProgress?: NotificationProgress, cancellationToken?: CancellationToken): Promise<void> {
+    ext.outputChannel.appendLog(getUploadingMessageWithSource(item.localFilePath, item.resourceName));
+
+    if (!ext.isWeb) {
+        // @todo: add code path for isWeb === true
+        await startAzCopyFileUpload(context, item, notificationProgress, cancellationToken);
+    }
+}
+
+export async function uploadFolder(context: IActionContext, item: UploadItem, messagePrefix?: string, notificationProgress?: NotificationProgress, cancellationToken?: CancellationToken): Promise<void> {
+    ext.outputChannel.appendLog(getUploadingMessageWithSource(item.localFilePath, item.resourceName));
+
+    if (!ext.isWeb) {
+        // @todo: add code path for isWeb === true
+        await startAzCopyFolderUpload(context, item, messagePrefix, notificationProgress, cancellationToken);
+    }
+
 }
 
 /**
@@ -87,17 +110,47 @@ function okToOverwriteOrDoesNotExist(context: IActionContext, item: DownloadItem
     return checkCanOverwrite(context, item.localFilePath, overwriteChoice, async () => await AzExtFsExtra.pathExists(item.localFilePath));
 }
 
-async function startAzCopyDownload(context: IDownloadWizardContext, progress: NotificationProgress, item: DownloadItem, cancellationToken?: CancellationToken): Promise<void> {
+async function startAzCopyDownload(context: IDownloadWizardContext, item: DownloadItem, progress?: NotificationProgress, cancellationToken?: CancellationToken): Promise<void> {
     const { azCopyTransfer } = await import("./azCopy/azCopyTransfer");
     const { createAzCopyLocalLocation, createAzCopyRemoteLocation } = await import("./azCopy/azCopyLocations");
 
     const src: IRemoteSasLocation = createAzCopyRemoteLocation(item.resourceUri, item.sasToken, item.remoteFilePath, item.isDirectory);
     const dst: ILocalLocation = createAzCopyLocalLocation(item.localFilePath);
     const fromTo: FromToOption = item.type === "blob" ? "BlobLocal" : "FileLocal";
-    const units: 'files' | 'bytes' = item.isDirectory ? 'files' : 'bytes';
+    const units: "files" | "bytes" = item.isDirectory ? "files" : "bytes";
     const transferProgress: TransferProgress = new TransferProgress(units, item.remoteFileName);
     await azCopyTransfer(context, fromTo, src, dst, transferProgress, progress, cancellationToken);
     if (item.isDirectory) {
         await AzExtFsExtra.ensureDir(item.localFilePath);
     }
+}
+
+async function startAzCopyFileUpload(context: IActionContext, item: UploadItem, notificationProgress?: NotificationProgress, cancellationToken?: CancellationToken) {
+    const { azCopyTransfer } = await import("./azCopy/azCopyTransfer");
+    const { createAzCopyLocalLocation, createAzCopyRemoteLocation } = await import("./azCopy/azCopyLocations");
+
+    const src: ILocalLocation = createAzCopyLocalLocation(item.localFilePath);
+    const dst: IRemoteSasLocation = createAzCopyRemoteLocation(item.resourceUri, item.transferSasToken, item.remoteFilePath);
+    const transferProgress: TransferProgress = new TransferProgress("bytes", item.remoteFilePath);
+    await azCopyTransfer(context, "LocalBlob", src, dst, transferProgress, notificationProgress, cancellationToken);
+}
+
+async function startAzCopyFolderUpload(context: IActionContext, item: UploadItem, messagePrefix?: string, notificationProgress?: NotificationProgress, cancellationToken?: CancellationToken): Promise<void> {
+    const { azCopyTransfer } = await import("./azCopy/azCopyTransfer");
+    const { createAzCopyLocalLocation, createAzCopyRemoteLocation } = await import("./azCopy/azCopyLocations");
+
+    let useWildCard: boolean = true;
+    if (await isEmptyDirectory(item.localFilePath)) {
+        useWildCard = false;
+        item.remoteFilePath = dirname(item.remoteFilePath);
+        if (item.remoteFilePath === ".") {
+            item.remoteFilePath = "";
+        }
+    }
+    const fromTo: FromToOption = item.type === "blob" ? "LocalBlob" : "LocalFile";
+
+    const src: ILocalLocation = createAzCopyLocalLocation(item.localFilePath, useWildCard);
+    const dst: IRemoteSasLocation = createAzCopyRemoteLocation(item.resourceUri, item.transferSasToken, item.remoteFilePath, false);
+    const transferProgress: TransferProgress = new TransferProgress("files", messagePrefix || item.remoteFilePath);
+    await azCopyTransfer(context, fromTo, src, dst, transferProgress, notificationProgress, cancellationToken);
 }

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as path from 'path';
+import * as vscode from 'vscode';
 import { Uri, workspace } from 'vscode';
 
 export function isPathEqual(fsPath1: string, fsPath2: string): boolean {
@@ -16,8 +17,12 @@ export function isSubpath(expectedParent: string, expectedChild: string): boolea
     return relativePath !== '' && !relativePath.startsWith('..') && relativePath !== expectedChild;
 }
 
-export async function isEmptyDirectory(uri: Uri): Promise<boolean> {
-    const files = await workspace.fs.readDirectory(uri);
+export async function isEmptyDirectory(pathOrUri: Uri | string): Promise<boolean> {
+    if (typeof pathOrUri === 'string') {
+        pathOrUri = vscode.Uri.file(pathOrUri)
+    }
+
+    const files = await workspace.fs.readDirectory(pathOrUri);
     if (files.length === 0) {
         return true;
     }


### PR DESCRIPTION
- Create functions for uploading files & folders in `tranfers.ts`
- Bring consistency to parameters in `transfers.ts`
- Remove remaining references to `azcopy-node` outside of transfers.ts and AzCopy specific files