### PR TITLE
Simplify AzureStorageFS readFile and pass along contents when creating a new blob in writeFile

### DIFF
--- a/src/utils/blobUtils.ts
+++ b/src/utils/blobUtils.ts
@@ -67,7 +67,7 @@ export async function createChildAsNewBlockBlob(parent: BlobContainerTreeItem | 
     return await vscode.window.withProgress({ location: vscode.ProgressLocation.Window }, async (progress) => {
         context.showCreatingTreeItem(blobPath);
         progress.report({ message: `Azure Storage: Creating block blob '${blobPath}'` });
-        await createOrUpdateBlockBlob(parent, blobPath);
+        await createOrUpdateBlockBlob(parent, blobPath, context?.contents || '');
         return new BlobTreeItem(parent, blobPath, parent.container);
     });
 }
@@ -148,4 +148,5 @@ export async function getBlobPath(context: IActionContext, parent: BlobContainer
 export interface IBlobContainerCreateChildContext extends IActionContext {
     childType: string;
     childName: string;
+    contents?: Buffer;
 }


### PR DESCRIPTION
Fixes #1286 

Previously, trying to view the blobs in an emulated blob container by opening a new explorer window would error when loading said blobs. This is resolved by using `client.downloadToBuffer()` similar to what is done in `readFile()` of BlobContainerFS.ts instead of manually handling and reading the chunks of the stream.

Also, dragging and dropping files into the explorer of an emulated blob container was not behaving as expected because `writeFile()` inside `AzureStorageFS.ts` which handles writing operations for emulated containers (opened in a new explorer window) creates an empty text file for newly created blobs. This fix passes along the blob contents to the existing `containerClient` calls where we perform blob uploads.

![out](https://github.com/microsoft/vscode-azurestorage/assets/111301956/6a7b023c-9618-44ab-b80d-89963134ee30)
