### PR TITLE
Edit the package script to install all versions of azcopy

### DIFF
--- a/package.json
+++ b/package.json
@@ -835,7 +835,7 @@
         "build": "tsc",
         "cleanReadme": "gulp cleanReadme",
         "compile": "tsc -watch",
-        "package": "vsce package --githubBranch main",
+        "package": "npm install --force @azure-tools/azcopy-darwin @azure-tools/azcopy-linux @azure-tools/azcopy-win32 @azure-tools/azcopy-win64 && vsce package --githubBranch main",
         "lint": "eslint --ext .ts .",
         "lint-fix": "eslint --ext .ts . --fix",
         "pretest": "gulp preTest",

--- a/package.json
+++ b/package.json
@@ -835,7 +835,7 @@
         "build": "tsc",
         "cleanReadme": "gulp cleanReadme",
         "compile": "tsc -watch",
-        "package": "npm install --force @azure-tools/azcopy-darwin @azure-tools/azcopy-linux @azure-tools/azcopy-win32 @azure-tools/azcopy-win64 && vsce package --githubBranch main",
+        "package": "npm install --force @azure-tools/azcopy-darwin @azure-tools/azcopy-linux @azure-tools/azcopy-win32 @azure-tools/azcopy-win64 && vsce package --no-dependencies --githubBranch main",
         "lint": "eslint --ext .ts .",
         "lint-fix": "eslint --ext .ts . --fix",
         "pretest": "gulp preTest",


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurestorage/issues/1262
Fixes https://github.com/microsoft/vscode-azurestorage/issues/1261

So this is the "easiest" way to do this, but it's also probably one of the ugliest...

We may be able to just add templates steps to do this, but it's also a one-off solution, so I feel okay just running the command via `npm run package`.

vsce package --no-dependencies is required to ignore all the errors caused by having OS specific packages on the wrong OS. Ideally, we could have 3 separate extensions for each OS runtime, but unless we're doing this via a pipeline, I don't feel comfortable making it part of the manual release process.

Note, we have been shipping a vsix with all 3 versions for years without issue.