### PR TITLE
Fix downloading from File Shares and Blob Containers

### DIFF
--- a/src/tree/blob/BlobTreeItem.ts
+++ b/src/tree/blob/BlobTreeItem.ts
@@ -66,6 +66,10 @@ export class BlobTreeItem extends AzExtTreeItem implements ICopyUrl, ITransferSr
         return this.blobName;
     }
 
+    public get blobContainerName(): string {
+        return this.container.name;
+    }
+
     public get iconPath(): TreeItemIconPath {
         return new vscode.ThemeIcon('file');
     }

--- a/src/tree/blob/BlobTreeItem.ts
+++ b/src/tree/blob/BlobTreeItem.ts
@@ -66,10 +66,6 @@ export class BlobTreeItem extends AzExtTreeItem implements ICopyUrl, ITransferSr
         return this.blobName;
     }
 
-    public get blobContainerName(): string {
-        return this.container.name;
-    }
-
     public get iconPath(): TreeItemIconPath {
         return new vscode.ThemeIcon('file');
     }

--- a/src/tree/fileShare/DirectoryTreeItem.ts
+++ b/src/tree/fileShare/DirectoryTreeItem.ts
@@ -20,7 +20,7 @@ import { threeDaysInMS } from '../../constants';
 import { ext } from "../../extensionVariables";
 import { copyAndShowToast } from '../../utils/copyAndShowToast';
 import { askAndCreateChildDirectory, deleteDirectoryAndContents, listFilesInDirectory } from '../../utils/directoryUtils';
-import { askAndCreateEmptyTextFile, createDirectoryClient, createFileClient } from '../../utils/fileUtils';
+import { askAndCreateEmptyTextFile, createDirectoryClient } from '../../utils/fileUtils';
 import { ICopyUrl } from '../ICopyUrl';
 import { IStorageRoot } from '../IStorageRoot';
 import { ITransferSrcOrDstTreeItem } from '../ITransferSrcOrDstTreeItem';
@@ -82,13 +82,11 @@ export class DirectoryTreeItem extends AzExtParentTreeItem implements ICopyUrl, 
         this._continuationToken = continuationToken;
 
         const fileTreeItems: FileTreeItem[] = await Promise.all(files.map(async (file: FileItem) => {
-            const shareClient = await createFileClient(this.root, this.shareName, this.directoryName, file.name);
-            return new FileTreeItem(this, file.name, this.fullPath, this.shareName, shareClient.url);
+            return new FileTreeItem(this, file.name, this.fullPath, this.shareName, this.resourceUri);
         }));
 
         const directoryTreeItems: DirectoryTreeItem[] = await Promise.all(directories.map(async (directory: DirectoryItem) => {
-            const directoryClient = await createDirectoryClient(this.root, this.shareName, directory.name);
-            return new DirectoryTreeItem(this, this.fullPath, directory.name, this.shareName, directoryClient.url);
+            return new DirectoryTreeItem(this, this.fullPath, directory.name, this.shareName, this.resourceUri);
         }));
 
         return (<(DirectoryTreeItem | FileTreeItem)[]>[])

--- a/src/utils/blobUtils.ts
+++ b/src/utils/blobUtils.ts
@@ -49,14 +49,12 @@ export async function loadMoreBlobChildren(parent: BlobContainerTreeItem | BlobD
     const children: AzExtTreeItem[] = [];
     for (const blob of responseValue.segment.blobItems) {
         // NOTE: `blob.name` as returned from Azure is actually the blob path in the container
-        const innerContainerClient = await createBlobContainerClient(parent.root, blob.name);
-        children.push(new BlobTreeItem(parent, blob.name, parent.container, innerContainerClient.url));
+        children.push(new BlobTreeItem(parent, blob.name, parent.container, containerClient.url));
     }
 
     for (const directory of responseValue.segment.blobPrefixes || []) {
         // NOTE: `directory.name` as returned from Azure is actually the directory path in the container
-        const innerContainerClient = await createBlobContainerClient(parent.root, directory.name);
-        children.push(new BlobDirectoryTreeItem(parent, directory.name, parent.container, innerContainerClient.url));
+        children.push(new BlobDirectoryTreeItem(parent, directory.name, parent.container, containerClient.url));
     }
 
     return { children, continuationToken };


### PR DESCRIPTION
Fix #1349 

Basically fixed the `resourceUri` so that we reference the parent (File Share or Blob Container) URI which is what the old implementation expects to work properly.

I tried downloading all combinations of the files/folders below and it is working again... if you can think of anything else to try let me know.

![image](https://github.com/user-attachments/assets/1b73f792-26cf-4764-8726-51dbad22ac22)

![image](https://github.com/user-attachments/assets/04f67a79-a343-42a2-815e-9e21757e30b4)

