### PR TITLE
Install azcopy in build pipeline

### DIFF
--- a/.azure-pipelines/1esmain.yml
+++ b/.azure-pipelines/1esmain.yml
@@ -42,3 +42,4 @@ extends:
     useAzureFederatedCredentials: ${{ parameters.enableLongRunningTests }}
     additionalSetupSteps:
       - script: npm install --force @azure-tools/azcopy-darwin @azure-tools/azcopy-linux @azure-tools/azcopy-win32 @azure-tools/azcopy-win64
+        name: Install azcopy

--- a/.azure-pipelines/1esmain.yml
+++ b/.azure-pipelines/1esmain.yml
@@ -40,3 +40,5 @@ extends:
   template: azure-pipelines/1esmain.yml@azExtTemplates
   parameters:
     useAzureFederatedCredentials: ${{ parameters.enableLongRunningTests }}
+    additionalSetupSteps:
+      - script: npm install --force @azure-tools/azcopy-darwin @azure-tools/azcopy-linux @azure-tools/azcopy-win32 @azure-tools/azcopy-win64

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,5 +18,38 @@ on:
 
 jobs:
   Build:
-    # Use template from https://github.com/microsoft/vscode-azuretools/tree/main/.github/workflows
-    uses: microsoft/vscode-azuretools/.github/workflows/jobs.yml@main
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: "."
+
+    steps:
+      # Setup
+      - uses: actions/checkout@v3
+      - name: Using Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: .nvmrc
+      - run: npm ci --no-optional
+      - run: npm install --force @azure-tools/azcopy-darwin @azure-tools/azcopy-linux @azure-tools/azcopy-win32 @azure-tools/azcopy-win64
+
+      # Lint
+      - run: npm run lint
+
+      # Build
+      - run: npm run build
+
+      # Package
+      - run: npm run package
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: Artifacts
+          path: |
+            **/*.vsix
+            **/*.tgz
+            !**/node_modules
+
+      # Test
+      - run: xvfb-run -a npm test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,7 @@ on:
       - main
       - rel/*
 
+# not using shared template (https://github.com/microsoft/vscode-azuretools/tree/main/.github/workflows) so that we can install azcopy
 jobs:
   Build:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -788,7 +788,6 @@
     },
     "scripts": {
         "vscode:prepublish": "npm run webpack-prod",
-        "preinstall": "npm install --force @azure-tools/azcopy-darwin @azure-tools/azcopy-linux @azure-tools/azcopy-win32 @azure-tools/azcopy-win64",
         "postinstall": "gulp setAzCopyExePermissions",
         "build": "tsc",
         "cleanReadme": "gulp cleanReadme",


### PR DESCRIPTION
It's better to do this as a build step rather than a preinstall script so it doesn't impact local development.