### PR TITLE
Add viewProperties model to get full data of storage account

### DIFF
--- a/src/tree/StorageAccountTreeItem.ts
+++ b/src/tree/StorageAccountTreeItem.ts
@@ -16,6 +16,7 @@ import { QueueServiceClient, StorageSharedKeyCredential as StorageSharedKeyCrede
 import { StorageAccountKey, StorageManagementClient } from '@azure/arm-storage';
 import { AzExtParentTreeItem, AzExtTreeItem, AzureWizard, DeleteConfirmationStep, DialogResponses, IActionContext, ISubscriptionContext, UserCancelledError } from '@microsoft/vscode-azext-utils';
 import { ResolvedAppResourceTreeItem } from '@microsoft/vscode-azext-utils/hostapi';
+import { ViewPropertiesModel } from '@microsoft/vscode-azureresources-api';
 import { MessageItem, commands, window } from 'vscode';
 import { ResolvedStorageAccount } from '../StorageAccountResolver';
 import { DeleteStorageAccountStep } from '../commands/deleteStorageAccount/DeleteStorageAccountStep';
@@ -87,7 +88,12 @@ export class StorageAccountTreeItem implements ResolvedStorageAccount, IStorageT
     public label: string = this.storageAccount.name;
     public static contextValue: string = 'azureStorageAccount';
     public contextValuesToAdd: string[] = [StorageAccountTreeItem.contextValue];
-
+    viewProperties: ViewPropertiesModel = {
+        getData: async () => {
+            return this.storageAccount
+        },
+        label: this.label
+    }
     // eslint-disable-next-line @typescript-eslint/require-await
     async loadMoreChildrenImpl(_clearCache: boolean): Promise<AzExtTreeItem[]> {
         this._blobContainerGroupTreeItem = new BlobContainerGroupTreeItem(this as unknown as (AzExtParentTreeItem & ResolvedAppResourceTreeItem<ResolvedStorageAccount>));


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurestorage/issues/1298

We can't just write it as a data property because the Resource Groups extension doesn't update the data property on the node when it resolves resources from other extensions.  By using the `getData` property instead, it will recognize that there's a new property from the storage resolver and use that instead.

Kind of a wonky workaround until we ever migrate everything to v2.