### PR TITLE
Use azurite settings for listening to emulator

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -23,6 +23,8 @@ export const emulatorTimeoutMS: number = 3 * 1000;
 export const emulatorAccountName: string = 'devstoreaccount1';
 export const emulatorConnectionString: string = 'UseDevelopmentStorage=true;';
 export const emulatorKey: string = 'Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==';
+export const azuriteKey: string = 'azurite'
+export const defaultEmulatorHost: string = '127.0.0.1';
 
 export const maxRemoteFileEditSizeMB: number = 50;
 export const maxRemoteFileEditSizeBytes: number = maxRemoteFileEditSizeMB * 1024 * 1024;

--- a/src/tree/AttachedStorageAccountTreeItem.ts
+++ b/src/tree/AttachedStorageAccountTreeItem.ts
@@ -144,7 +144,8 @@ class AttachedStorageRoot extends AttachedAccountRoot {
             const blobPort = getWorkspaceSetting('blobPort', undefined, azuriteKey) || '10000';
 
             const sharedKeyCredential = new StorageSharedKeyCredentialBlob(emulatorAccountName, emulatorKey);
-            return new BlobServiceClient(`http://${blobEndpoint}:${blobPort}/${emulatorAccountName}`, sharedKeyCredential);
+            const protocol = getTransferProtocol();
+            return new BlobServiceClient(`${protocol}://${blobEndpoint}:${blobPort}/${emulatorAccountName}`, sharedKeyCredential);
         }
 
         return BlobServiceClient.fromConnectionString(this._connectionString, this._serviceClientPipelineOptions);
@@ -160,7 +161,8 @@ class AttachedStorageRoot extends AttachedAccountRoot {
             const queuePort = getWorkspaceSetting('queuePort', undefined, azuriteKey) || '10001';
 
             const sharedKeyCredential = new StorageSharedKeyCredentialQueue(emulatorAccountName, emulatorKey);
-            return new QueueServiceClient(`http://${queueEndpoint}:${queuePort}/${emulatorAccountName}`, sharedKeyCredential);
+            const protocol = getTransferProtocol();
+            return new QueueServiceClient(`${protocol}://${queueEndpoint}:${queuePort}/${emulatorAccountName}`, sharedKeyCredential);
         }
 
         return QueueServiceClient.fromConnectionString(this._connectionString, this._serviceClientPipelineOptions);
@@ -172,9 +174,14 @@ class AttachedStorageRoot extends AttachedAccountRoot {
             const tablePort = getWorkspaceSetting('tablePort', undefined, azuriteKey) || '10002';
 
             const sharedKeyCredential = new AzureNamedKeyCredential(emulatorAccountName, emulatorKey);
-            return new TableServiceClient(`http://${tableEndpoint}:${tablePort}/${emulatorAccountName}`, sharedKeyCredential, { allowInsecureConnection: true });
+            const protocol = getTransferProtocol();
+            return new TableServiceClient(`${protocol}://${tableEndpoint}:${tablePort}/${emulatorAccountName}`, sharedKeyCredential, { allowInsecureConnection: protocol === 'http' });
         }
 
         return TableServiceClient.fromConnectionString(this._connectionString, { retryOptions: { maxRetries: this._serviceClientPipelineOptions.retryOptions.maxTries } });
     }
+}
+
+function getTransferProtocol(): string {
+    return getWorkspaceSetting('cert', undefined, azuriteKey) && getWorkspaceSetting('key', undefined, azuriteKey) ? 'https' : 'http';
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurestorage/issues/1385

The sdk recognized `UseDevelopmentStorage=true` as a native connection string, however that would limit users to only being able to use the default host and port.

This will read Azurite's settings and use those if they exist.