### PR TITLE
Manually refresh whenever fireDeleteEvent happens in workspace view

### DIFF
--- a/src/AzureStorageFS.ts
+++ b/src/AzureStorageFS.ts
@@ -101,7 +101,9 @@ export class AzureStorageFS implements vscode.FileSystemProvider, vscode.TextDoc
         await vscode.window.showTextDocument(doc, { preserveFocus: false, preview: false });
     }
 
-    public static fireDeleteEvent(node: AzExtTreeItem): void {
+    public static fireDeleteEvent(context: IActionContext, node: AzExtTreeItem): void {
+        // refresh the workspaceResourceTree to reflect changes in attached accounts since azureStorageFS doesn't seem to refresh the workspace view
+        void ext.rgApi.workspaceResourceTree.refresh(context);
         ext.azureStorageFS.fireSoon({ uri: AzureStorageFS.idToUri(node.fullId), type: vscode.FileChangeType.Deleted });
     }
 

--- a/src/tree/blob/BlobContainerTreeItem.ts
+++ b/src/tree/blob/BlobContainerTreeItem.ts
@@ -166,7 +166,7 @@ export class BlobContainerTreeItem extends AzExtParentTreeItem implements ICopyU
             await containerClient.delete();
         }
 
-        AzureStorageFS.fireDeleteEvent(this);
+        AzureStorageFS.fireDeleteEvent(context, this);
     }
 
     public async createChildImpl(context: ICreateChildImplContext & Partial<IExistingFileContext> & IBlobContainerCreateChildContext): Promise<AzExtTreeItem> {

--- a/src/tree/blob/BlobDirectoryTreeItem.ts
+++ b/src/tree/blob/BlobDirectoryTreeItem.ts
@@ -135,6 +135,6 @@ export class BlobDirectoryTreeItem extends AzExtParentTreeItem implements ICopyU
         }
         await wizard.execute();
 
-        AzureStorageFS.fireDeleteEvent(this);
+        AzureStorageFS.fireDeleteEvent(context, this);
     }
 }

--- a/src/tree/blob/BlobTreeItem.ts
+++ b/src/tree/blob/BlobTreeItem.ts
@@ -108,7 +108,7 @@ export class BlobTreeItem extends AzExtTreeItem implements ICopyUrl, ITransferSr
             const blobClient: BlobClient = await createBlobClient(this.root, this.container.name, this.blobPath);
             await blobClient.delete();
         }
-        AzureStorageFS.fireDeleteEvent(this);
+        AzureStorageFS.fireDeleteEvent(context, this);
     }
 
     public async checkCanDownload(context: IActionContext): Promise<void> {

--- a/src/tree/fileShare/DirectoryTreeItem.ts
+++ b/src/tree/fileShare/DirectoryTreeItem.ts
@@ -129,7 +129,7 @@ export class DirectoryTreeItem extends AzExtParentTreeItem implements ICopyUrl, 
             throw new UserCancelledError();
         }
 
-        AzureStorageFS.fireDeleteEvent(this);
+        AzureStorageFS.fireDeleteEvent(context, this);
     }
 }
 

--- a/src/tree/fileShare/FileShareTreeItem.ts
+++ b/src/tree/fileShare/FileShareTreeItem.ts
@@ -124,7 +124,7 @@ export class FileShareTreeItem extends AzExtParentTreeItem implements ICopyUrl, 
             throw new UserCancelledError();
         }
 
-        AzureStorageFS.fireDeleteEvent(this);
+        AzureStorageFS.fireDeleteEvent(context, this);
     }
 
     public async createChildImpl(context: ICreateChildImplContext & Partial<IExistingFileContext> & IFileShareCreateChildContext): Promise<AzExtTreeItem> {

--- a/src/tree/fileShare/FileTreeItem.ts
+++ b/src/tree/fileShare/FileTreeItem.ts
@@ -83,6 +83,6 @@ export class FileTreeItem extends AzExtTreeItem implements ICopyUrl, ITransferSr
             throw new UserCancelledError();
         }
 
-        AzureStorageFS.fireDeleteEvent(this);
+        AzureStorageFS.fireDeleteEvent(context, this);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurestorage/issues/1394

This was occurring for blobs, blob containers, file shares, and files, not just blobs like the issue indicates.