### PR TITLE
Don't save client on storage tree item, creates too many issues

### DIFF
--- a/src/commands/createStorageAccount.ts
+++ b/src/commands/createStorageAccount.ts
@@ -78,8 +78,9 @@ export async function createStorageAccount(context: IActionContext & Partial<ICr
 
     // In case this account has been created via a deploy or browse command, the enable website hosting prompt shouldn't be shown
     (<ISelectStorageAccountContext>context).showEnableWebsiteHostingPrompt = false;
-
-    return (wizardContext as unknown as IStorageAccountTreeItemCreateContext).accountTreeItem;
+    const storageAccountTreeItem = (wizardContext as unknown as IStorageAccountTreeItemCreateContext).accountTreeItem;
+    await storageAccountTreeItem.initStorageAccount(wizardContext);
+    return storageAccountTreeItem;
 }
 
 export async function createStorageAccountAdvanced(actionContext: IActionContext, treeItem?: SubscriptionTreeItem): Promise<StorageAccountTreeItem> {

--- a/src/tree/AttachedStorageAccountTreeItem.ts
+++ b/src/tree/AttachedStorageAccountTreeItem.ts
@@ -10,7 +10,7 @@ import { ShareServiceClient } from '@azure/storage-file-share';
 import { QueueServiceClient, StorageSharedKeyCredential as StorageSharedKeyCredentialQueue } from '@azure/storage-queue';
 
 import { StorageManagementClient } from '@azure/arm-storage';
-import { AzExtParentTreeItem, AzExtTreeItem } from '@microsoft/vscode-azext-utils';
+import { AzExtParentTreeItem, AzExtTreeItem, IActionContext } from '@microsoft/vscode-azext-utils';
 import * as path from 'path';
 import { AttachedAccountRoot } from '../AttachedAccountRoot';
 import { azuriteKey, defaultEmulatorHost, emulatorAccountName, emulatorConnectionString, emulatorKey, getResourcesPath } from '../constants';
@@ -124,7 +124,7 @@ class AttachedStorageRoot extends AttachedAccountRoot {
         throw new Error(localize('cannotRetrieveStorageAccountIdForAttachedAccount', 'Cannot retrieve storage account id for an attached account.'));
     }
 
-    public getStorageManagementClient(): StorageManagementClient {
+    public async getStorageManagementClient(_context: IActionContext): Promise<StorageManagementClient> {
         throw new Error(localize('cannotRetrieveStorageAccountIdForAttachedAccount', 'Cannot retrieve storage management client for an attached account.'));
     }
 

--- a/src/tree/IStorageRoot.ts
+++ b/src/tree/IStorageRoot.ts
@@ -8,7 +8,8 @@ import type { AccountSASSignatureValues as AccountSASSignatureValuesBlob, BlobSe
 import type { AccountSASSignatureValues as AccountSASSignatureValuesFileShare, ShareServiceClient } from "@azure/storage-file-share";
 import type { QueueServiceClient } from "@azure/storage-queue";
 
-import { Endpoints, StorageManagementClient } from "@azure/arm-storage";
+import { type Endpoints, type StorageManagementClient } from "@azure/arm-storage";
+import { type IActionContext } from "@microsoft/vscode-azext-utils";
 
 export interface IStorageRoot {
     storageAccountName: string;
@@ -16,7 +17,7 @@ export interface IStorageRoot {
     isEmulated: boolean;
     primaryEndpoints?: Endpoints;
     generateSasToken(accountSASSignatureValues: AccountSASSignatureValuesBlob | AccountSASSignatureValuesFileShare): string;
-    getStorageManagementClient(): StorageManagementClient;
+    getStorageManagementClient(context: IActionContext): Promise<StorageManagementClient>;
     createBlobServiceClient(): Promise<BlobServiceClient>;
     createShareServiceClient(): Promise<ShareServiceClient>;
     createQueueServiceClient(): Promise<QueueServiceClient>;


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurestorage/issues/1410

Made some calls async (such as getting the key, client, etc.) since we can't assume everything is initialized anymore.