### PR TITLE
Check sharedKeyAccess property before trying to use key

### DIFF
--- a/src/commands/createStorageAccount.ts
+++ b/src/commands/createStorageAccount.ts
@@ -78,8 +78,9 @@ export async function createStorageAccount(context: IActionContext & Partial<ICr
 
     // In case this account has been created via a deploy or browse command, the enable website hosting prompt shouldn't be shown
     (<ISelectStorageAccountContext>context).showEnableWebsiteHostingPrompt = false;
-
-    return (wizardContext as unknown as IStorageAccountTreeItemCreateContext).accountTreeItem;
+    const storageAccountTreeItem = (wizardContext as unknown as IStorageAccountTreeItemCreateContext).accountTreeItem;
+    await storageAccountTreeItem.initStorageAccount(wizardContext);
+    return storageAccountTreeItem;
 }
 
 export async function createStorageAccountAdvanced(actionContext: IActionContext, treeItem?: SubscriptionTreeItem): Promise<StorageAccountTreeItem> {

--- a/src/commands/storageAccountActionHandlers.ts
+++ b/src/commands/storageAccountActionHandlers.ts
@@ -44,7 +44,8 @@ export async function copyPrimaryKey(context: IActionContext, treeItem?: Storage
     }
 
     await treeItem.initStorageAccount(context);
-    await copyAndShowToast(treeItem.key.value, 'Primary key');
+    const key = await treeItem.getKey();
+    await copyAndShowToast(key.value, 'Primary key');
 }
 
 export async function copyConnectionString(context: IActionContext, treeItem?: StorageAccountTreeItem): Promise<void> {

--- a/src/commands/storageAccountActionHandlers.ts
+++ b/src/commands/storageAccountActionHandlers.ts
@@ -53,7 +53,7 @@ export async function copyConnectionString(context: IActionContext, treeItem?: S
     }
 
     await treeItem.initStorageAccount(context);
-    const connectionString = treeItem.getConnectionString();
+    const connectionString = await treeItem.getConnectionString();
     await copyAndShowToast(connectionString, 'Connection string');
 }
 

--- a/src/tree/AttachedStorageAccountTreeItem.ts
+++ b/src/tree/AttachedStorageAccountTreeItem.ts
@@ -10,7 +10,7 @@ import { ShareServiceClient } from '@azure/storage-file-share';
 import { QueueServiceClient, StorageSharedKeyCredential as StorageSharedKeyCredentialQueue } from '@azure/storage-queue';
 
 import { StorageManagementClient } from '@azure/arm-storage';
-import { AzExtParentTreeItem, AzExtTreeItem } from '@microsoft/vscode-azext-utils';
+import { AzExtParentTreeItem, AzExtTreeItem, IActionContext } from '@microsoft/vscode-azext-utils';
 import * as path from 'path';
 import { AttachedAccountRoot } from '../AttachedAccountRoot';
 import { azuriteKey, defaultEmulatorHost, emulatorAccountName, emulatorConnectionString, emulatorKey, getResourcesPath } from '../constants';
@@ -124,7 +124,7 @@ class AttachedStorageRoot extends AttachedAccountRoot {
         throw new Error(localize('cannotRetrieveStorageAccountIdForAttachedAccount', 'Cannot retrieve storage account id for an attached account.'));
     }
 
-    public getStorageManagementClient(): StorageManagementClient {
+    public async getStorageManagementClient(_context: IActionContext): Promise<StorageManagementClient> {
         throw new Error(localize('cannotRetrieveStorageAccountIdForAttachedAccount', 'Cannot retrieve storage management client for an attached account.'));
     }
 

--- a/src/tree/IStorageRoot.ts
+++ b/src/tree/IStorageRoot.ts
@@ -8,7 +8,8 @@ import type { AccountSASSignatureValues as AccountSASSignatureValuesBlob, BlobSe
 import type { AccountSASSignatureValues as AccountSASSignatureValuesFileShare, ShareServiceClient } from "@azure/storage-file-share";
 import type { QueueServiceClient } from "@azure/storage-queue";
 
-import { Endpoints, StorageManagementClient } from "@azure/arm-storage";
+import { type Endpoints, type StorageManagementClient } from "@azure/arm-storage";
+import { type IActionContext } from "@microsoft/vscode-azext-utils";
 
 export interface IStorageRoot {
     storageAccountName: string;
@@ -16,7 +17,7 @@ export interface IStorageRoot {
     isEmulated: boolean;
     primaryEndpoints?: Endpoints;
     generateSasToken(accountSASSignatureValues: AccountSASSignatureValuesBlob | AccountSASSignatureValuesFileShare): string;
-    getStorageManagementClient(): StorageManagementClient;
+    getStorageManagementClient(context: IActionContext): Promise<StorageManagementClient>;
     createBlobServiceClient(): Promise<BlobServiceClient>;
     createShareServiceClient(): Promise<ShareServiceClient>;
     createQueueServiceClient(): Promise<QueueServiceClient>;

--- a/src/tree/StorageAccountTreeItem.ts
+++ b/src/tree/StorageAccountTreeItem.ts
@@ -13,7 +13,7 @@ import { BlobServiceClient, StorageSharedKeyCredential as StorageSharedKeyCreden
 import { ShareServiceClient, StorageSharedKeyCredential as StorageSharedKeyCredentialFileShare } from '@azure/storage-file-share';
 import { QueueServiceClient, StorageSharedKeyCredential as StorageSharedKeyCredentialQueue } from '@azure/storage-queue';
 
-import { StorageAccountKey } from '@azure/arm-storage';
+import { StorageAccount, StorageAccountKey } from '@azure/arm-storage';
 import { getResourceGroupFromId } from '@microsoft/vscode-azext-azureutils';
 import { AzExtParentTreeItem, AzExtTreeItem, AzureWizard, DeleteConfirmationStep, DialogResponses, IActionContext, ISubscriptionContext, UserCancelledError, callWithTelemetryAndErrorHandling } from '@microsoft/vscode-azext-utils';
 import { ResolvedAppResourceTreeItem } from '@microsoft/vscode-azext-utils/hostapi';
@@ -55,7 +55,10 @@ export type StorageQueryResult = {
     name: string,
     resourceGroup: string,
     subscriptionId: string,
-    type: string
+    type: string,
+    properties: {
+        allowSharedKeyAccess: boolean
+    }
 }
 
 export type ResolvedStorageAccountTreeItem = ResolvedAppResourceTreeItem<ResolvedStorageAccount>;
@@ -79,30 +82,37 @@ export class StorageAccountTreeItem implements ResolvedStorageAccount, IStorageT
     private _tableGroupTreeItem: TableGroupTreeItem;
     private _root: IStorageRoot | undefined = undefined;
     private _storageAccount: StorageAccountWrapper | undefined = undefined;
+    private _allowSharedKeyAccess: boolean;
 
     constructor(subscription: ISubscriptionContext,
-        storageAccount: StorageAccountWrapper | undefined,
+        storageAccount: StorageAccount | undefined,
         dataModel?: StorageQueryResult
     ) {
         this._subscription = subscription;
         if (storageAccount) {
-            this._storageAccount = storageAccount;
+            this._storageAccount = new StorageAccountWrapper(storageAccount);
             this.dataModel = this.createDataModelFromStorageAccount(storageAccount);
         }
 
         if (dataModel) {
             this.dataModel = dataModel;
         }
+
+        this._allowSharedKeyAccess = !!this.dataModel?.properties.allowSharedKeyAccess;
     }
 
-    public createDataModelFromStorageAccount(storageAccount: StorageAccountWrapper): StorageQueryResult {
+    public createDataModelFromStorageAccount(storageAccount: StorageAccount): StorageQueryResult {
+        const storageAccountWrapper = new StorageAccountWrapper(storageAccount);
         return {
-            id: storageAccount.id,
-            location: storageAccount.location,
-            name: storageAccount.name,
-            resourceGroup: getResourceGroupFromId(storageAccount.id),
+            id: storageAccountWrapper.id,
+            location: storageAccountWrapper.location,
+            name: storageAccountWrapper.name,
+            resourceGroup: getResourceGroupFromId(storageAccountWrapper.id),
             subscriptionId: this._subscription.subscriptionId,
-            type: storageAccount.type
+            type: storageAccountWrapper.type,
+            properties: {
+                allowSharedKeyAccess: !!storageAccount.allowSharedKeyAccess
+            }
         };
     }
 
@@ -131,7 +141,9 @@ export class StorageAccountTreeItem implements ResolvedStorageAccount, IStorageT
             const storageAccount = await client.storageAccounts.getProperties(this.dataModel.resourceGroup, this.dataModel.name);
             this._storageAccount = new StorageAccountWrapper(storageAccount);
             this.dataModel = this.createDataModelFromStorageAccount(this.storageAccount);
-            await this.refreshKey(context);
+            if (this._allowSharedKeyAccess) {
+                await this.refreshKey(context);
+            }
             this._root = this.createRoot();
         }
 
@@ -201,6 +213,10 @@ export class StorageAccountTreeItem implements ResolvedStorageAccount, IStorageT
     }
 
     async getKey(): Promise<StorageAccountKeyWrapper> {
+        if (!this._allowSharedKeyAccess) {
+            throw new Error(localize('storageAccountTreeItem.noSharedKeyAccess', 'No shared key access for storage account "{0}". Allow it to enable this command.', this.label));
+        }
+
         await callWithTelemetryAndErrorHandling('storageAccountTreeItem.getKey', async (context: IActionContext) => {
             if (!this._key) {
                 await this.refreshKey(context);
@@ -251,6 +267,10 @@ export class StorageAccountTreeItem implements ResolvedStorageAccount, IStorageT
             isEmulated: false,
             primaryEndpoints: this.storageAccount.primaryEndpoints,
             generateSasToken: (accountSASSignatureValues: AccountSASSignatureValues) => {
+                if (!this._allowSharedKeyAccess) {
+                    throw new Error(localize('storageAccountTreeItem.noSharedKeyAccess', 'No shared key access for storage account "{0}". Allow it to enable this command.', this.label));
+                }
+
                 return generateAccountSASQueryParameters(
                     accountSASSignatureValues,
                     new StorageSharedKeyCredentialBlob(this.storageAccount.name, this._key.value)
@@ -260,12 +280,18 @@ export class StorageAccountTreeItem implements ResolvedStorageAccount, IStorageT
                 return await createStorageClient([context, this._subscription]);
             },
             createBlobServiceClient: async () => {
-                let client: BlobServiceClient;
-                try {
-                    const credential = new StorageSharedKeyCredentialBlob(this.storageAccount.name, ((await this.getKey()).value));
-                    client = new BlobServiceClient(nonNullProp(this.storageAccount.primaryEndpoints, 'blob'), credential);
-                    await client.getProperties(); // Trigger a request to validate the key
-                } catch (error) {
+                let client: BlobServiceClient | undefined = undefined;
+                if (this._allowSharedKeyAccess) {
+                    try {
+                        const credential = new StorageSharedKeyCredentialBlob(this.storageAccount.name, ((await this.getKey()).value));
+                        client = new BlobServiceClient(nonNullProp(this.storageAccount.primaryEndpoints, 'blob'), credential);
+                        await client.getProperties(); // Trigger a request to validate the key
+                    } catch (error) {
+                        // ignore and try scoped token
+                    }
+                }
+
+                if (!client) {
                     const token = await this._subscription.createCredentialsForScopes(['https://storage.azure.com/.default']);
                     client = new BlobServiceClient(nonNullProp(this.storageAccount.primaryEndpoints, 'blob'), token);
                     await client.getProperties(); // Trigger a request to validate the token
@@ -274,12 +300,17 @@ export class StorageAccountTreeItem implements ResolvedStorageAccount, IStorageT
                 return client;
             },
             createShareServiceClient: async () => {
-                let client: ShareServiceClient;
-                try {
-                    const credential = new StorageSharedKeyCredentialFileShare(this.storageAccount.name, ((await this.getKey()).value));
-                    client = new ShareServiceClient(nonNullProp(this.storageAccount.primaryEndpoints, 'file'), credential);
-                    await client.getProperties(); // Trigger a request to validate the key
-                } catch (error) {
+                let client: ShareServiceClient | undefined = undefined;
+                if (this._allowSharedKeyAccess) {
+                    try {
+                        const credential = new StorageSharedKeyCredentialFileShare(this.storageAccount.name, ((await this.getKey()).value));
+                        client = new ShareServiceClient(nonNullProp(this.storageAccount.primaryEndpoints, 'file'), credential);
+                        await client.getProperties(); // Trigger a request to validate the key
+                    } catch (error) {
+                        // ignore and try scoped token
+                    }
+                }
+                if (!client) {
                     const token = await this._subscription.createCredentialsForScopes(['https://storage.azure.com/.default']);
                     client = new ShareServiceClient(nonNullProp(this.storageAccount.primaryEndpoints, 'file'), token, { fileRequestIntent: 'backup' });
                     await client.getProperties(); // Trigger a request to validate the token
@@ -288,12 +319,17 @@ export class StorageAccountTreeItem implements ResolvedStorageAccount, IStorageT
                 return client;
             },
             createQueueServiceClient: async () => {
-                let client: QueueServiceClient;
-                try {
-                    const credential = new StorageSharedKeyCredentialQueue(this.storageAccount.name, ((await this.getKey()).value));
-                    client = new QueueServiceClient(nonNullProp(this.storageAccount.primaryEndpoints, 'queue'), credential);
-                    await client.getProperties(); // Trigger a request to validate the key
-                } catch (error) {
+                let client: QueueServiceClient | undefined = undefined;
+                if (this._allowSharedKeyAccess) {
+                    try {
+                        const credential = new StorageSharedKeyCredentialQueue(this.storageAccount.name, ((await this.getKey()).value));
+                        client = new QueueServiceClient(nonNullProp(this.storageAccount.primaryEndpoints, 'queue'), credential);
+                        await client.getProperties(); // Trigger a request to validate the key
+                    } catch (error) {
+                        // ignore and try scoped token
+                    }
+                }
+                if (!client) {
                     const token = await this._subscription.createCredentialsForScopes(['https://storage.azure.com/.default']);
                     client = new QueueServiceClient(nonNullProp(this.storageAccount.primaryEndpoints, 'queue'), token);
                     await client.getProperties(); // Trigger a request to validate the token
@@ -302,12 +338,17 @@ export class StorageAccountTreeItem implements ResolvedStorageAccount, IStorageT
                 return client;
             },
             createTableServiceClient: async () => {
-                let client: TableServiceClient;
-                try {
-                    const credential = new AzureNamedKeyCredential(this.storageAccount.name, ((await this.getKey()).value));
-                    client = new TableServiceClient(nonNullProp(this.storageAccount.primaryEndpoints, 'table'), credential);
-                    await client.getProperties(); // Trigger a request to validate the key
-                } catch (error) {
+                let client: TableServiceClient | undefined = undefined;
+                if (this._allowSharedKeyAccess) {
+                    try {
+                        const credential = new AzureNamedKeyCredential(this.storageAccount.name, ((await this.getKey()).value));
+                        client = new TableServiceClient(nonNullProp(this.storageAccount.primaryEndpoints, 'table'), credential);
+                        await client.getProperties(); // Trigger a request to validate the key
+                    } catch (error) {
+                        // ignore and try scoped token
+                    }
+                }
+                if (!client) {
                     const token = await this._subscription.createCredentialsForScopes(['https://storage.azure.com/.default']);
                     client = new TableServiceClient(nonNullProp(this.storageAccount.primaryEndpoints, 'table'), token);
                     await client.getProperties(); // Trigger a request to validate the token

--- a/src/tree/createWizard/StorageAccountTreeItemCreateStep.ts
+++ b/src/tree/createWizard/StorageAccountTreeItemCreateStep.ts
@@ -7,7 +7,6 @@ import { IStorageAccountWizardContext } from "@microsoft/vscode-azext-azureutils
 import { AzureWizardExecuteStep, ExecuteActivityContext, ISubscriptionContext } from "@microsoft/vscode-azext-utils";
 import { AppResource } from "@microsoft/vscode-azext-utils/hostapi";
 import { nonNullProp } from '../../utils/nonNull';
-import { StorageAccountWrapper } from "../../utils/storageWrappers";
 import { StorageAccountTreeItem } from "../StorageAccountTreeItem";
 
 export interface IStorageAccountTreeItemCreateContext extends IStorageAccountWizardContext, ExecuteActivityContext {
@@ -24,7 +23,7 @@ export class StorageAccountTreeItemCreateStep extends AzureWizardExecuteStep<ISt
     }
 
     public async execute(wizardContext: IStorageAccountTreeItemCreateContext): Promise<void> {
-        wizardContext.accountTreeItem = new StorageAccountTreeItem(this.subscription, new StorageAccountWrapper(nonNullProp(wizardContext, 'storageAccount')));
+        wizardContext.accountTreeItem = new StorageAccountTreeItem(this.subscription, nonNullProp(wizardContext, 'storageAccount'));
 
         const appResource: AppResource = {
             id: wizardContext.accountTreeItem.storageAccount.id,


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurestorage/issues/967

This pull request introduces significant improvements to how storage account keys and connection strings are managed, with a focus on supporting accounts that may not allow shared key access. It adds checks for shared key access before attempting operations that require it, refactors key retrieval to be asynchronous and more robust, and updates related interfaces and usages throughout the codebase.

**Key changes:**

### Shared Key Access Handling and API Changes

* Updated the `getKey`, `refreshKey`, and `getConnectionString` methods to be asynchronous and to check for shared key access before proceeding. Errors are thrown or handled gracefully if access is not allowed
* Modified the `IStorageRoot` interface and related implementations to require an `IActionContext` parameter and return a promise for `getStorageManagementClient`, supporting asynchronous and context-aware client creation. 