### PR TITLE
Add changes to allow OAuth/RBAC for azcopy calls

### DIFF
--- a/src/commands/downloadFiles/GetAzCopyDownloadsStep.ts
+++ b/src/commands/downloadFiles/GetAzCopyDownloadsStep.ts
@@ -38,7 +38,7 @@ export class GetAzCopyDownloadsStep extends AzureWizardExecuteStep<IDownloadWiza
         for (const treeItem of treeItems) {
             // if there is no remoteFilePath, then it is the root
             const remoteFilePath = treeItem.remoteFilePath ?? `${posix.sep}`;
-            const sasToken = treeItem.transferSasToken;
+            const token = treeItem.root.allowSharedKeyAccess ? treeItem.transferSasToken : await treeItem.root.getAccessToken();
             const resourceUri = treeItem.resourceUri;
             if (treeItem instanceof BlobTreeItem) {
                 await treeItem.checkCanDownload(context);
@@ -49,7 +49,9 @@ export class GetAzCopyDownloadsStep extends AzureWizardExecuteStep<IDownloadWiza
                     localFilePath: join(destinationFolder, treeItem.blobName),
                     isDirectory: false,
                     resourceUri,
-                    sasToken
+                    sasToken: token,
+                    accessToken: token,
+                    tenantId: treeItem.subscription.tenantId
                 });
             } else if (treeItem instanceof BlobDirectoryTreeItem) {
                 allFolderDownloads.push({
@@ -59,7 +61,8 @@ export class GetAzCopyDownloadsStep extends AzureWizardExecuteStep<IDownloadWiza
                     localFilePath: join(destinationFolder, treeItem.dirName),
                     isDirectory: true,
                     resourceUri,
-                    sasToken
+                    sasToken: token,
+                    accessToken: token
                 });
             } else if (treeItem instanceof BlobContainerTreeItem) {
                 allFolderDownloads.push({
@@ -69,7 +72,8 @@ export class GetAzCopyDownloadsStep extends AzureWizardExecuteStep<IDownloadWiza
                     localFilePath: join(destinationFolder, treeItem.container.name),
                     isDirectory: true,
                     resourceUri,
-                    sasToken
+                    sasToken: token,
+                    accessToken: token
                 });
             } else if (treeItem instanceof FileTreeItem) {
                 allFileDownloads.push({
@@ -79,7 +83,8 @@ export class GetAzCopyDownloadsStep extends AzureWizardExecuteStep<IDownloadWiza
                     localFilePath: join(destinationFolder, treeItem.fileName),
                     isDirectory: false,
                     resourceUri,
-                    sasToken,
+                    sasToken: token,
+                    accessToken: token,
                 });
             } else if (treeItem instanceof DirectoryTreeItem) {
                 allFolderDownloads.push({
@@ -89,7 +94,8 @@ export class GetAzCopyDownloadsStep extends AzureWizardExecuteStep<IDownloadWiza
                     localFilePath: join(destinationFolder, treeItem.directoryName),
                     isDirectory: true,
                     resourceUri,
-                    sasToken
+                    sasToken: token,
+                    accessToken: token
                 });
             } else if (treeItem instanceof FileShareTreeItem) {
                 allFolderDownloads.push({
@@ -99,7 +105,8 @@ export class GetAzCopyDownloadsStep extends AzureWizardExecuteStep<IDownloadWiza
                     localFilePath: join(destinationFolder, treeItem.shareName),
                     isDirectory: true,
                     resourceUri,
-                    sasToken
+                    sasToken: token,
+                    accessToken: token
                 });
             }
         }

--- a/src/commands/transfers/azCopy/credentialStore.ts
+++ b/src/commands/transfers/azCopy/credentialStore.ts
@@ -1,0 +1,35 @@
+/*!---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *----------------------------------------------------------*/
+
+import { ICredentialStore } from "@azure-tools/azcopy-node";
+import { ext } from "../../../extensionVariables";
+
+export class CredentialStore implements ICredentialStore {
+    private credentialMap: Map<string, string> = new Map<string, string>();
+    public async setEntry(service: string, account: string, value: string): Promise<void> {
+        try {
+            this.credentialMap.set(`${service}-${account}`, value);
+        } catch (error) {
+            ext.outputChannel.appendLog(`Unable to set password. service:${service} account:${account}`, error);
+        }
+    }
+
+    public async getEntry(service: string, account: string): Promise<string | null> {
+        try {
+            return this.credentialMap.get(`${service}-${account}`) ?? null;
+        } catch (error) {
+            ext.outputChannel.appendLog(`Unable to get password. service:${service} account:${account}`, error);
+            return null;
+        }
+    }
+
+    public async deleteEntry(service: string, account: string): Promise<boolean> {
+        try {
+            return this.credentialMap.delete(`${service}-${account}`);
+        } catch (error) {
+            ext.outputChannel.appendLog(`Unable to delete password. service:${service} account:${account}`, error);
+            return false;
+        }
+    }
+}

--- a/src/tree/AttachedStorageAccountTreeItem.ts
+++ b/src/tree/AttachedStorageAccountTreeItem.ts
@@ -109,6 +109,7 @@ export class AttachedStorageAccountTreeItem extends AzExtParentTreeItem implemen
 class AttachedStorageRoot extends AttachedAccountRoot {
     public storageAccountName: string;
     public isEmulated: boolean;
+    public allowSharedKeyAccess: boolean = true;
 
     private readonly _serviceClientPipelineOptions = { retryOptions: { maxTries: 2 } };
     private _connectionString: string;
@@ -118,6 +119,9 @@ class AttachedStorageRoot extends AttachedAccountRoot {
         this._connectionString = connectionString;
         this.storageAccountName = storageAccountName;
         this.isEmulated = isEmulated;
+    }
+    public getAccessToken(): Promise<string> {
+        throw new Error(localize('cannotRetrieveAccessTokenForAttachedAccount', 'Cannot retrieve access token for an attached account.'));
     }
 
     public get storageAccountId(): string {

--- a/src/tree/IStorageRoot.ts
+++ b/src/tree/IStorageRoot.ts
@@ -15,7 +15,9 @@ export interface IStorageRoot {
     storageAccountName: string;
     storageAccountId: string;
     isEmulated: boolean;
+    allowSharedKeyAccess: boolean;
     primaryEndpoints?: Endpoints;
+    getAccessToken(): Promise<string>;
     generateSasToken(accountSASSignatureValues: AccountSASSignatureValuesBlob | AccountSASSignatureValuesFileShare): string;
     getStorageManagementClient(context: IActionContext): Promise<StorageManagementClient>;
     createBlobServiceClient(): Promise<BlobServiceClient>;

--- a/src/tree/StorageAccountTreeItem.ts
+++ b/src/tree/StorageAccountTreeItem.ts
@@ -266,7 +266,13 @@ export class StorageAccountTreeItem implements ResolvedStorageAccount, IStorageT
             storageAccountName: this.dataModel.name,
             storageAccountId: this.dataModel.id,
             isEmulated: false,
+            allowSharedKeyAccess: this.allowSharedKeyAccess,
             primaryEndpoints: this.storageAccount.primaryEndpoints,
+            getAccessToken: async (): Promise<string> => {
+                const credentials = await this._subscription.createCredentialsForScopes(['https://storage.azure.com/.default']);
+                const token = await credentials.getToken() as unknown as { token: string };
+                return token.token;
+            },
             generateSasToken: (accountSASSignatureValues: AccountSASSignatureValues) => {
                 if (!this.allowSharedKeyAccess) {
                     throw new Error(localize('storageAccountTreeItem.noSharedKeyAccess', 'No shared key access for storage account "{0}". Allow it to enable this command.', this.label));

--- a/src/tree/blob/BlobContainerTreeItem.ts
+++ b/src/tree/blob/BlobContainerTreeItem.ts
@@ -353,13 +353,18 @@ export class BlobContainerTreeItem extends AzExtParentTreeItem implements ICopyU
         notificationProgress?: NotificationProgress,
         cancellationToken?: vscode.CancellationToken
     ): Promise<void> {
+        // either sasToken or accessToken should be undefined; we use the according credential accordingly
+        const token = this.root.allowSharedKeyAccess ? this.transferSasToken : await this.root.getAccessToken();
         const uploadItem: UploadItem = {
             type: "blob",
+            isDirectory: false,
             localFilePath: filePath,
             resourceName: this.container.name,
             resourceUri: this.resourceUri,
             remoteFilePath: blobPath,
-            transferSasToken: this.transferSasToken,
+            sasToken: token,
+            accessToken: token,
+            tenantId: this.subscription.tenantId
         };
         await uploadFile(context, uploadItem, notificationProgress, cancellationToken);
     }

--- a/src/tree/fileShare/FileShareTreeItem.ts
+++ b/src/tree/fileShare/FileShareTreeItem.ts
@@ -162,14 +162,18 @@ export class FileShareTreeItem extends AzExtParentTreeItem implements ICopyUrl, 
                 await directoryClient.create();
             }
         }
-
+        // either sasToken or accessToken should be undefined; we use the according credential accordingly
+        const token = this.root.allowSharedKeyAccess ? this.transferSasToken : await this.root.getAccessToken();
         const uploadItem: UploadItem = {
             type: "file",
+            isDirectory: false,
             localFilePath: sourceFilePath,
             resourceName: this.shareName,
             resourceUri: this.resourceUri,
             remoteFilePath: destFilePath,
-            transferSasToken: this.transferSasToken,
+            sasToken: token,
+            accessToken: token,
+            tenantId: this.subscription.tenantId
         };
         await uploadFile(context, uploadItem, notificationProgress, cancellationToken);
     }

--- a/src/utils/uploadUtils.ts
+++ b/src/utils/uploadUtils.ts
@@ -36,13 +36,18 @@ export async function uploadLocalFolder(
     cancellationToken: vscode.CancellationToken,
     messagePrefix?: string,
 ): Promise<void> {
+    // either sasToken or accessToken should be undefined; we use the according credential accordingly
+    const token = destTreeItem.root.allowSharedKeyAccess ? destTreeItem.transferSasToken : await destTreeItem.root.getAccessToken();
     const uploadItem: UploadItem = {
         type: destTreeItem instanceof BlobContainerTreeItem ? "blob" : "file",
+        isDirectory: false,
         localFilePath: sourcePath,
         resourceName: destTreeItem instanceof BlobContainerTreeItem ? destTreeItem.container.name : destTreeItem.shareName,
         resourceUri: destTreeItem.resourceUri,
         remoteFilePath: destPath,
-        transferSasToken: destTreeItem.transferSasToken,
+        sasToken: token,
+        accessToken: token,
+        tenantId: destTreeItem.subscription.tenantId
     }
     await uploadFolder(context, uploadItem, messagePrefix, notificationProgress, cancellationToken);
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurestorage/issues/1401
Fixes https://github.com/microsoft/vscode-azurestorage/issues/1441

Pardon my messy PR, unfortunately all of it is required in order to get OAuth to work.

First of all, AzCopy requires you create a credentialStore if you are going to use access tokens. I'm assuming for long running operations, it may need to retrieve the token multiple times or something.

Next, all of the weird accessToken/sasToken logic branches. Basically, without a huge refactoring, it's just easier to pass in both, but assume that if one is defined, that the other is undefined (or can safely be ignored).

I think that should cover why I had to make most of these changes.